### PR TITLE
feat(proto): Timestamp.to_milis(), RefUnwindSafe

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -35,6 +35,7 @@ time = { version = "0.3", default-features = false, features = [
     "parsing",
 ] }
 flex-error = { version = "0.4.4", default-features = false }
+chrono = { version = "0.4.24", default-features = false }
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/proto/src/serializers/timestamp.rs
+++ b/proto/src/serializers/timestamp.rs
@@ -27,6 +27,20 @@ impl From<Rfc3339> for Timestamp {
     }
 }
 
+pub trait ToMilis {
+    /// Convert protobuf timestamp into miliseconds since epoch
+    fn to_milis(&self) -> u64;
+}
+
+impl ToMilis for Timestamp {
+    /// Convert protobuf timestamp into miliseconds since epoch
+    fn to_milis(&self) -> u64 {
+        chrono::NaiveDateTime::from_timestamp_opt(self.seconds, self.nanos as u32)
+            .unwrap()
+            .timestamp_millis() as u64
+    }
+}
+
 /// Deserialize string into Timestamp
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Timestamp, D::Error>
 where


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Dash platform uses time in miliseconds.
Also, to recover from panics, Server needs to implement std::panic::RefUnwindSafe 

## What was done?

1. Added method to convert timestamp to miliseconds since epoch.
2. Server and RequestDispatcher implements std::panic::RefUnwindSafe to be able to detect panics in unwind


## How Has This Been Tested?

Tested as part of integration with Dash Platform.

## Breaking Changes

2. Server and RequestDispatcher must implement std::panic::RefUnwindSafe

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
