### PR TITLE
revert(abci): remove RefUniwndSafe trait from RequestDispatcher

### DIFF
--- a/abci/src/application.rs
+++ b/abci/src/application.rs
@@ -1,5 +1,4 @@
 //! ABCI application interface.
-use std::panic::RefUnwindSafe;
 
 use tracing::debug;
 
@@ -139,7 +138,7 @@ pub trait Application {
     }
 }
 
-pub trait RequestDispatcher: RefUnwindSafe {
+pub trait RequestDispatcher {
     /// Executes the relevant application method based on the type of the
     /// request, and produces the corresponding response.
     ///
@@ -149,7 +148,7 @@ pub trait RequestDispatcher: RefUnwindSafe {
 }
 
 // Implement `RequestDispatcher` for all `Application`s.
-impl<A: Application + RefUnwindSafe> RequestDispatcher for A {
+impl<A: Application> RequestDispatcher for A {
     fn handle(&self, request: abci::Request) -> Option<abci::Response> {
         tracing::trace!(?request, "received request");
 

--- a/abci/src/server.rs
+++ b/abci/src/server.rs
@@ -6,7 +6,6 @@ mod unix;
 use std::{
     io::{Read, Write},
     net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
-    panic::RefUnwindSafe,
     str::FromStr,
 };
 
@@ -24,7 +23,7 @@ pub(crate) const DEFAULT_SERVER_READ_BUF_SIZE: usize = 1024 * 1024;
 /// Use [`Server::handle_connection()`] to accept connection and process all
 /// traffic in this connection. Each incoming connection will be processed using
 /// `app`.
-pub trait Server: RefUnwindSafe {
+pub trait Server {
     /// Process one incoming connection.
     ///
     /// Returns when the connection is terminated or RequestDispatcher returns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented


Requirement of RefUniwndSafe on RequestDispatcher makes it hard to implement an Application.

## What was done?

Removed RefUnwindSafe from RequestDispatcher and Server traits.

## How Has This Been Tested?

github pipelines green

## Breaking Changes

Server no longer implements RefUnwindSafe


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
