### PR TITLE
feat(abci): support tracing::span inside rs-tenderdash-abci

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -11,7 +11,7 @@ description = """tenderdash-abci provides a simple framework with which to build
 low-level applications on top of Tenderdash."""
 
 [features]
-default = ["server", "docker-tests", "crypto", "tcp", "unix"]
+default = ["server", "docker-tests", "crypto", "tcp", "unix", "tracing-span"]
 # docker-tests includes integration tests that require docker to be available
 docker-tests = ["server"]
 server = [
@@ -23,6 +23,7 @@ server = [
 crypto = ["dep:lhash"]
 tcp = ["server"]
 unix = ["server"]
+tracing-span = []
 
 [[example]]
 name = "echo_socket"

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -23,13 +23,14 @@ server = [
 crypto = ["dep:lhash"]
 tcp = ["server"]
 unix = ["server"]
-tracing-span = []
+tracing-span = ["dep:uuid"]
 
 [[example]]
 name = "echo_socket"
 required-features = ["server"]
 
 [dependencies]
+uuid = { version = "1.4.1", features = ["v4", "fast-rng"], optional = true }
 tenderdash-proto = { version = "0.13.0-dev.2", path = "../proto" }
 bytes = { version = "1.0" }
 prost = { version = "0.11" }

--- a/abci/src/application.rs
+++ b/abci/src/application.rs
@@ -179,7 +179,6 @@ impl<A: Application> RequestDispatcher for A {
         }
         .unwrap_or_else(|e| e.into());
 
-        // TODO: errors as err
         if let response::Value::Exception(ref exception) = response {
             tracing::error!(response=?exception, "sending ABCI exception");
         } else {

--- a/abci/src/application.rs
+++ b/abci/src/application.rs
@@ -180,7 +180,7 @@ impl<A: Application> RequestDispatcher for A {
         .unwrap_or_else(|e| e.into());
 
         if let response::Value::Exception(_) = response {
-            tracing::error!(response=?response, "sending ABCI exception");
+            tracing::error!(?response, "sending ABCI exception");
         } else {
             tracing::trace!(?response, "sending ABCI response");
         };

--- a/abci/src/application.rs
+++ b/abci/src/application.rs
@@ -179,8 +179,8 @@ impl<A: Application> RequestDispatcher for A {
         }
         .unwrap_or_else(|e| e.into());
 
-        if let response::Value::Exception(ref exception) = response {
-            tracing::error!(response=?exception, "sending ABCI exception");
+        if let response::Value::Exception(_) = response {
+            tracing::error!(response=?response, "sending ABCI exception");
         } else {
             tracing::trace!(?response, "sending ABCI response");
         };

--- a/abci/src/application.rs
+++ b/abci/src/application.rs
@@ -1,8 +1,6 @@
 //! ABCI application interface.
 
-use hex::ToHex;
-use tenderdash_proto::abci::request::Value;
-use tracing::{debug, Level};
+use tracing::debug;
 
 use crate::proto::{
     abci,
@@ -153,7 +151,7 @@ pub trait RequestDispatcher {
 impl<A: Application> RequestDispatcher for A {
     fn handle(&self, request: abci::Request) -> Option<abci::Response> {
         #[cfg(feature = "tracing-span")]
-        let _span = enter_span(request.clone().value?);
+        let _span = super::tracing_span::span(request.clone().value?);
         tracing::trace!(?request, "received request");
 
         let response: Result<response::Value, abci::ResponseException> = match request.value? {
@@ -191,85 +189,6 @@ impl<A: Application> RequestDispatcher for A {
             value: Some(response),
         })
     }
-}
-#[cfg(feature = "tracing-span")]
-fn enter_span<T>(request: T) -> tracing::span::EnteredSpan
-where
-    T: Into<request::Value>,
-{
-    let value = request.into();
-    const SPAN_NAME: &str = "abci";
-    const LEVEL: Level = Level::ERROR;
-    let endpoint = abci_method_name(&value);
-
-    let span = match value {
-        Value::Info(r) => tracing::span!(
-            LEVEL,
-            SPAN_NAME,
-            endpoint,
-            tenderdash_version = r.version,
-            block_version = r.block_version,
-            p2p_version = r.p2p_version,
-        ),
-        Value::InitChain(r) => {
-            tracing::span!(LEVEL, SPAN_NAME, endpoint, chain_id = r.chain_id)
-        },
-        Value::PrepareProposal(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                height = r.height,
-                round = r.round,
-                quorum_hash = r.quorum_hash.encode_hex::<String>(),
-                core_locked_height = r.core_chain_locked_height,
-            )
-        },
-        Value::ProcessProposal(r) => tracing::span!(
-            LEVEL,
-            SPAN_NAME,
-            endpoint,
-            r.height,
-            r.round,
-            quorum_hash = r.quorum_hash.encode_hex::<String>(),
-            r.core_chain_locked_height,
-        ),
-        Value::ExtendVote(r) => tracing::span!(LEVEL, SPAN_NAME, endpoint, r.height, r.round),
-        Value::VerifyVoteExtension(r) => {
-            tracing::span!(LEVEL, SPAN_NAME, endpoint, r.height, r.round)
-        },
-        Value::FinalizeBlock(r) => tracing::span!(LEVEL, SPAN_NAME, endpoint, r.height, r.round),
-        Value::CheckTx(r) => {
-            tracing::span!(LEVEL, SPAN_NAME, endpoint, tx = r.tx.encode_hex::<String>())
-        },
-        Value::Query(r) => {
-            tracing::span!(LEVEL, SPAN_NAME, endpoint, path = r.path)
-        },
-        _ => tracing::span!(LEVEL, SPAN_NAME, endpoint),
-    };
-
-    span.entered()
-}
-#[cfg(feature = "tracing-span")]
-fn abci_method_name(request: &Value) -> String {
-    match request {
-        Value::ApplySnapshotChunk(_) => "ApplySnapshotChunk",
-        Value::CheckTx(_) => "CheckTx",
-        Value::Echo(_) => "Echo",
-        Value::ExtendVote(_) => "ExtendVote",
-        Value::FinalizeBlock(_) => "FinalizeBlock",
-        Value::Flush(_) => "Flush",
-        Value::Info(_) => "Info",
-        Value::InitChain(_) => "InitChain",
-        Value::ListSnapshots(_) => "ListSnapshots",
-        Value::LoadSnapshotChunk(_) => "LoadSnapshotChunk",
-        Value::OfferSnapshot(_) => "OfferSnapshot",
-        Value::PrepareProposal(_) => "PrepareProposal",
-        Value::ProcessProposal(_) => "ProcessProposal",
-        Value::Query(_) => "Query",
-        Value::VerifyVoteExtension(_) => "VerifyVoteExtension",
-    }
-    .to_string()
 }
 
 /// Check if ABCI version sent by Tenderdash matches version of linked protobuf

--- a/abci/src/application.rs
+++ b/abci/src/application.rs
@@ -152,9 +152,9 @@ impl<A: Application> RequestDispatcher for A {
     fn handle(&self, request: abci::Request) -> Option<abci::Response> {
         #[cfg(feature = "tracing-span")]
         let _span = super::tracing_span::span(request.clone().value?);
-        tracing::trace!(?request, "received request");
+        tracing::trace!(?request, "received ABCI request");
 
-        let response: Result<response::Value, abci::ResponseException> = match request.value? {
+        let response: response::Value = match request.value? {
             request::Value::Echo(req) => self.echo(req).map(|v| v.into()),
             request::Value::Flush(req) => self.flush(req).map(|v| v.into()),
             request::Value::Info(req) => self.info(req).map(|v| v.into()),
@@ -176,14 +176,15 @@ impl<A: Application> RequestDispatcher for A {
             request::Value::VerifyVoteExtension(req) => {
                 self.verify_vote_extension(req).map(|v| v.into())
             },
-        };
+        }
+        .unwrap_or_else(|e| e.into());
 
-        let response = match response {
-            Ok(v) => v,
-            Err(e) => response::Value::from(e),
+        // TODO: errors as err
+        if let response::Value::Exception(ref exception) = response {
+            tracing::error!(response=?exception, "sending ABCI exception");
+        } else {
+            tracing::trace!(?response, "sending ABCI response");
         };
-
-        tracing::trace!(?response, "sending response");
 
         Some(abci::Response {
             value: Some(response),

--- a/abci/src/lib.rs
+++ b/abci/src/lib.rs
@@ -26,6 +26,8 @@ pub use tenderdash_proto as proto;
 
 #[cfg(feature = "crypto")]
 pub mod signatures;
+#[cfg(feature = "tracing-span")]
+mod tracing_span;
 
 /// Errors that may happen during protobuf communication
 #[derive(Debug, thiserror::Error)]

--- a/abci/src/lib.rs
+++ b/abci/src/lib.rs
@@ -27,7 +27,8 @@ pub use tenderdash_proto as proto;
 #[cfg(feature = "crypto")]
 pub mod signatures;
 #[cfg(feature = "tracing-span")]
-mod tracing_span;
+/// Create tracing::Span for better logging
+pub mod tracing_span;
 
 /// Errors that may happen during protobuf communication
 #[derive(Debug, thiserror::Error)]

--- a/abci/src/server/generic.rs
+++ b/abci/src/server/generic.rs
@@ -106,15 +106,15 @@ where
         let mut codec = Codec::new(listener, cancel_token.clone(), &self.runtime);
         while !cancel_token.is_cancelled() {
             let Some(request) = codec.next() else {
-            tracing::error!("client terminated stream");
-            return Ok(())
-        };
+                tracing::error!("client terminated stream");
+                return Ok(());
+            };
 
-            let Some(response) = self.app.handle(request.clone())  else {
-            // `RequestDispatcher` decided to stop receiving new requests:
-            info!("ABCI Application is shutting down");
-            return Ok(());
-        };
+            let Some(response) = self.app.handle(request.clone()) else {
+                // `RequestDispatcher` decided to stop receiving new requests:
+                info!("ABCI Application is shutting down");
+                return Ok(());
+            };
 
             if let Some(crate::proto::abci::response::Value::Exception(ex)) = response.value.clone()
             {

--- a/abci/src/tracing_span.rs
+++ b/abci/src/tracing_span.rs
@@ -1,0 +1,121 @@
+use hex::ToHex;
+use tenderdash_proto::abci::request::Value;
+use tracing::Level;
+pub(super) fn span<T>(request: T) -> tracing::span::EnteredSpan
+where
+    T: Into<Value>,
+{
+    let value = request.into();
+    const SPAN_NAME: &str = "abci";
+    const LEVEL: Level = Level::ERROR;
+    let endpoint = abci_method_name(&value);
+    let request_id = uuid::Uuid::new_v4().to_string();
+
+    let span = match value {
+        Value::Info(r) => tracing::span!(
+            LEVEL,
+            SPAN_NAME,
+            endpoint,
+            request_id,
+            tenderdash_version = r.version,
+            block_version = r.block_version,
+            p2p_version = r.p2p_version,
+        ),
+        Value::InitChain(r) => {
+            tracing::span!(
+                LEVEL,
+                SPAN_NAME,
+                endpoint,
+                request_id,
+                chain_id = r.chain_id
+            )
+        },
+        Value::PrepareProposal(r) => {
+            tracing::span!(
+                LEVEL,
+                SPAN_NAME,
+                endpoint,
+                request_id,
+                height = r.height,
+                round = r.round,
+                quorum_hash = r.quorum_hash.encode_hex::<String>(),
+                core_locked_height = r.core_chain_locked_height,
+            )
+        },
+        Value::ProcessProposal(r) => tracing::span!(
+            LEVEL,
+            SPAN_NAME,
+            endpoint,
+            request_id,
+            height = r.height,
+            round = r.round,
+            quorum_hash = r.quorum_hash.encode_hex::<String>(),
+            core_locked_height = r.core_chain_locked_height,
+        ),
+        Value::ExtendVote(r) => {
+            tracing::span!(
+                LEVEL,
+                SPAN_NAME,
+                endpoint,
+                request_id,
+                height = r.height,
+                round = r.round
+            )
+        },
+        Value::VerifyVoteExtension(r) => {
+            tracing::span!(
+                LEVEL,
+                SPAN_NAME,
+                endpoint,
+                request_id,
+                height = r.height,
+                round = r.round
+            )
+        },
+        Value::FinalizeBlock(r) => {
+            tracing::span!(
+                LEVEL,
+                SPAN_NAME,
+                endpoint,
+                request_id,
+                height = r.height,
+                round = r.round
+            )
+        },
+        Value::CheckTx(r) => {
+            tracing::span!(
+                LEVEL,
+                SPAN_NAME,
+                endpoint,
+                request_id,
+                tx = r.tx.encode_hex::<String>()
+            )
+        },
+        Value::Query(r) => {
+            tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id, path = r.path)
+        },
+        _ => tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id),
+    };
+
+    span.entered()
+}
+fn abci_method_name(request: &Value) -> String {
+    match request {
+        Value::ApplySnapshotChunk(_) => "ApplySnapshotChunk",
+        Value::CheckTx(_) => "CheckTx",
+        Value::Echo(_) => "Echo",
+        Value::ExtendVote(_) => "ExtendVote",
+        Value::FinalizeBlock(_) => "FinalizeBlock",
+        Value::Flush(_) => "Flush",
+        Value::Info(_) => "Info",
+        Value::InitChain(_) => "InitChain",
+        Value::ListSnapshots(_) => "ListSnapshots",
+        Value::LoadSnapshotChunk(_) => "LoadSnapshotChunk",
+        Value::OfferSnapshot(_) => "OfferSnapshot",
+        Value::PrepareProposal(_) => "PrepareProposal",
+        Value::ProcessProposal(_) => "ProcessProposal",
+        Value::Query(_) => "Query",
+        Value::VerifyVoteExtension(_) => "VerifyVoteExtension",
+    }
+    .to_string()
+}

--- a/abci/src/tracing_span.rs
+++ b/abci/src/tracing_span.rs
@@ -1,7 +1,7 @@
-use hex::ToHex;
 use tenderdash_proto::abci::request::Value;
 use tracing::Level;
-pub(super) fn span<T>(request: T) -> tracing::span::EnteredSpan
+
+pub fn span<T>(request: T) -> tracing::span::EnteredSpan
 where
     T: Into<Value>,
 {
@@ -12,23 +12,9 @@ where
     let request_id = uuid::Uuid::new_v4().to_string();
 
     let span = match value {
-        Value::Info(r) => tracing::span!(
-            LEVEL,
-            SPAN_NAME,
-            endpoint,
-            request_id,
-            tenderdash_version = r.version,
-            block_version = r.block_version,
-            p2p_version = r.p2p_version,
-        ),
-        Value::InitChain(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                request_id,
-                chain_id = r.chain_id
-            )
+        Value::Info(_r) => tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id),
+        Value::InitChain(_r) => {
+            tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id)
         },
         Value::PrepareProposal(r) => {
             tracing::span!(
@@ -38,8 +24,6 @@ where
                 request_id,
                 height = r.height,
                 round = r.round,
-                quorum_hash = r.quorum_hash.encode_hex::<String>(),
-                core_locked_height = r.core_chain_locked_height,
             )
         },
         Value::ProcessProposal(r) => tracing::span!(
@@ -49,8 +33,6 @@ where
             request_id,
             height = r.height,
             round = r.round,
-            quorum_hash = r.quorum_hash.encode_hex::<String>(),
-            core_locked_height = r.core_chain_locked_height,
         ),
         Value::ExtendVote(r) => {
             tracing::span!(
@@ -82,14 +64,8 @@ where
                 round = r.round
             )
         },
-        Value::CheckTx(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                request_id,
-                tx = r.tx.encode_hex::<String>()
-            )
+        Value::CheckTx(_r) => {
+            tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id)
         },
         Value::Query(r) => {
             tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id, path = r.path)

--- a/abci/src/tracing_span.rs
+++ b/abci/src/tracing_span.rs
@@ -1,13 +1,52 @@
 use tenderdash_proto::abci::request::Value;
 use tracing::Level;
 
+const SPAN_NAME: &str = "abci";
+const LEVEL: Level = Level::ERROR;
+
+macro_rules! block_span {
+    ($request: expr, $endpoint:expr, $request_id:expr) => {
+        tracing::span!(
+            LEVEL,
+            SPAN_NAME,
+            endpoint = $endpoint,
+            request_id = $request_id,
+            height = $request.height,
+            round = $request.round
+        )
+    };
+}
+/// Creates a new span for tracing.
+///
+/// This function creates a new `tracing::span::EnteredSpan` based on the
+/// provided request. It uses the request to determine the endpoint and includes
+/// a unique request ID in the span.
+///
+/// The level of the span is set to ERROR, so it will be included on all log
+/// levels.
+///
+/// # Arguments
+///
+/// * `request` - A value that can be converted into a `Value`. Depending on the
+///   specific variant of `Value`, additional information like height, round, or
+///   path might be included in the span.
+///
+/// # Returns
+///
+/// An entered span which represents an active or entered span state.
+///
+/// # Examples
+///
+/// ```
+/// let request = Value::Info(RequestInfo::new());
+/// let span = span(request);
+/// ```
 pub fn span<T>(request: T) -> tracing::span::EnteredSpan
 where
     T: Into<Value>,
 {
     let value = request.into();
-    const SPAN_NAME: &str = "abci";
-    const LEVEL: Level = Level::ERROR;
+
     let endpoint = abci_method_name(&value);
     let request_id = uuid::Uuid::new_v4().to_string();
 
@@ -16,54 +55,11 @@ where
         Value::InitChain(_r) => {
             tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id)
         },
-        Value::PrepareProposal(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                request_id,
-                height = r.height,
-                round = r.round,
-            )
-        },
-        Value::ProcessProposal(r) => tracing::span!(
-            LEVEL,
-            SPAN_NAME,
-            endpoint,
-            request_id,
-            height = r.height,
-            round = r.round,
-        ),
-        Value::ExtendVote(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                request_id,
-                height = r.height,
-                round = r.round
-            )
-        },
-        Value::VerifyVoteExtension(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                request_id,
-                height = r.height,
-                round = r.round
-            )
-        },
-        Value::FinalizeBlock(r) => {
-            tracing::span!(
-                LEVEL,
-                SPAN_NAME,
-                endpoint,
-                request_id,
-                height = r.height,
-                round = r.round
-            )
-        },
+        Value::PrepareProposal(r) => block_span!(r, endpoint, request_id),
+        Value::ProcessProposal(r) => block_span!(r, endpoint, request_id),
+        Value::ExtendVote(r) => block_span!(r, endpoint, request_id),
+        Value::VerifyVoteExtension(r) => block_span!(r, endpoint, request_id),
+        Value::FinalizeBlock(r) => block_span!(r, endpoint, request_id),
         Value::CheckTx(_r) => {
             tracing::span!(LEVEL, SPAN_NAME, endpoint, request_id)
         },
@@ -75,6 +71,7 @@ where
 
     span.entered()
 }
+
 fn abci_method_name(request: &Value) -> String {
     match request {
         Value::ApplySnapshotChunk(_) => "ApplySnapshotChunk",

--- a/abci/src/tracing_span.rs
+++ b/abci/src/tracing_span.rs
@@ -38,7 +38,10 @@ macro_rules! block_span {
 /// # Examples
 ///
 /// ```
-/// let request = Value::Info(RequestInfo::new());
+/// # use tenderdash_proto::abci::{RequestInfo, request};
+/// # use tenderdash_abci::tracing_span::span;
+///
+/// let request = request::Value::Info(RequestInfo::default());
 /// let span = span(request);
 /// ```
 pub fn span<T>(request: T) -> tracing::span::EnteredSpan

--- a/abci/tests/kvstore.rs
+++ b/abci/tests/kvstore.rs
@@ -227,7 +227,9 @@ impl Application for KVStoreABCI<'_> {
             .collect::<Option<BTreeSet<Operation>>>()
         else {
             error!("Cannot decode transactions");
-            return Err(abci::ResponseException {error:"cannot decode transactions".to_string()});
+            return Err(abci::ResponseException {
+                error: "cannot decode transactions".to_string(),
+            });
         };
 
         // Mark transactions that should be added to the proposed transactions
@@ -253,7 +255,9 @@ impl Application for KVStoreABCI<'_> {
 
         let Some(tx_records) = tx_records_encoded else {
             error!("cannot encode transactions");
-            return Err(ResponseException{error:"cannot encode transactions".to_string()});
+            return Err(ResponseException {
+                error: "cannot encode transactions".to_string(),
+            });
         };
 
         // Put both local and proposed transactions into staging area
@@ -286,7 +290,9 @@ impl Application for KVStoreABCI<'_> {
             .map(decode_transaction)
             .collect::<Option<BTreeSet<Operation>>>()
         else {
-            return Err(ResponseException{error:"cannot decode transactions".to_string()});
+            return Err(ResponseException {
+                error: "cannot decode transactions".to_string(),
+            });
         };
 
         let tx_results = tx_results_accept(td_proposed_transactions.len());

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -90,6 +90,7 @@ pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.types.TxProof", SERIALIZED),
     (".tendermint.crypto.Proof", SERIALIZED),
     (".tendermint.abci.Response.value", DERIVE_FROM),
+    (".tendermint.abci.Request.value", DERIVE_FROM),
 ];
 
 /// Custom field attributes applied on top of protobuf fields in (a) struct(s)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We need to log events with some predefined metadata, like height and round.

## What was done?

Implemented `tracing-span` feature that adds a span before each request is processed.

This feature is enabled by default.

The span includes:

* endpoint
* request_id
* height
* round

## How Has This Been Tested

Started local devnet and investigated logs.

## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
