### PR TITLE
fix(tenderdash-abci): ensure crate features build without default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-
+resolver = "2"
 members = ["abci", "proto-compiler", "proto"]

--- a/abci/src/lib.rs
+++ b/abci/src/lib.rs
@@ -21,6 +21,7 @@ use std::io;
 pub use application::{check_version, Application, RequestDispatcher};
 use prost::{DecodeError, EncodeError};
 #[allow(deprecated)]
+#[cfg(feature = "server")]
 pub use server::{start_server, CancellationToken, Server, ServerBuilder};
 pub use tenderdash_proto as proto;
 

--- a/abci/src/server/generic.rs
+++ b/abci/src/server/generic.rs
@@ -1,11 +1,15 @@
 //! Generic ABCI server
+#[cfg(feature = "tcp")]
+use std::net::ToSocketAddrs;
+use std::{fmt::Debug, sync::Arc};
+#[cfg(feature = "unix")]
+use std::{fs, path::Path};
 
-use std::{fmt::Debug, fs, net::ToSocketAddrs, path::Path, sync::Arc};
-
-use tokio::{
-    net::{TcpListener, UnixListener},
-    sync::Mutex,
-};
+#[cfg(feature = "tcp")]
+use tokio::net::TcpListener;
+#[cfg(feature = "unix")]
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
 use tokio_util::net::Listener;
 use tracing::info;
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -16,7 +16,9 @@ description = """
 all-features = true
 
 [dependencies]
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.12", default-features = false, features = [
+    "prost-derive",
+] }
 bytes = { version = "1.0", default-features = false, features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 subtle-encoding = { version = "0.5", default-features = false, features = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Build tenderdash-abci doesn't work reliably when switching various features on and off.


## What was done?

1. Added some conditional compilation clauses.
2. Fixed `prost` dependency of `tenderdash-proto` crate to include missing `prost-derive` feature, which is required

## How Has This Been Tested?

Try to build with various combinations of features.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
