### PR TITLE
feat: use TENDERDASH_COMMITISH env var to set tenderdash rev to use

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -3,10 +3,17 @@ use std::env;
 fn main() {
     let version = env!("CARGO_PKG_VERSION");
 
-    env::set_var("TENDERDASH_COMMITISH", "v".to_owned() + version);
+    // check if TENDERDASH_COMMITISH is alrady set; if not, set it to the current
+    // version
+    let commitish = env::var("TENDERDASH_COMMITISH").unwrap_or_default();
+    if commitish.is_empty() {
+        env::set_var("TENDERDASH_COMMITISH", "v".to_owned() + version);
+    }
+
     tenderdash_proto_compiler::proto_compile();
 
     println!("cargo:rerun-if-changed=../proto-compiler/src");
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+    println!("cargo:rerun-if-env-changed=TENDERDASH_COMMITISH");
 }

--- a/proto/src/prelude.rs
+++ b/proto/src/prelude.rs
@@ -1,5 +1,6 @@
 // Re-export according to alloc::prelude::v1 because it is not yet stabilized
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
+#[allow(unused_imports)]
 pub use alloc::{
     borrow::ToOwned,
     boxed::Box,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We need a way to use custom revision of Tenderdash 


## What was done?

TENDERDASH_COMMITISH env var can now contain Tenderdash commit hash to use when fetching TD sources.

For example:

```
export TENDERDASH_COMMITISH=b1942323f5e6377014f7bb02f46879855307069b
cargo build
```

## How Has This Been Tested?

Locally 

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
