### PR TITLE
build(deps): use protoc 25.2

### DIFF
--- a/.github/actions/deps/action.yaml
+++ b/.github/actions/deps/action.yaml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         curl -Lo /tmp/protoc.zip \
-          https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-25.2-linux-x86_64.zip
+          https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip
         unzip /tmp/protoc.zip -d ${HOME}/.local
         echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
         export PATH="${PATH}:${HOME}/.local/bin"

--- a/.github/actions/deps/action.yaml
+++ b/.github/actions/deps/action.yaml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         curl -Lo /tmp/protoc.zip \
-          https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-x86_64.zip
+          https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-25.2-linux-x86_64.zip
         unzip /tmp/protoc.zip -d ${HOME}/.local
         echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
         export PATH="${PATH}:${HOME}/.local/bin"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -23,7 +23,7 @@ ARG BUILDPLATFORM
 # Install protoc - protobuf compiler
 # The one shipped with Alpine does not work
 RUN if [[ "$BUILDPLATFORM" == "linux/arm64" ]] ; then export PROTOC_ARCH=aarch_64; else export PROTOC_ARCH=x86_64 ; fi; \
-    wget -q -O /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-linux-${PROTOC_ARCH}.zip && \
+    wget -q -O /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-${PROTOC_ARCH}.zip && \
     unzip -qd /opt/protoc /tmp/protoc.zip && \
     rm /tmp/protoc.zip && \
     ln -s /opt/protoc/bin/protoc /usr/bin/

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -8,10 +8,17 @@ RUN --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update -qq && \
     apt-get install -qq --yes \
-        protobuf-compiler \
         git \
         wget \
         bash
+
+# Install protoc - protobuf compiler
+# The one shipped with Alpine does not work
+RUN if [[ "$BUILDPLATFORM" == "linux/arm64" ]] ; then export PROTOC_ARCH=aarch_64; else export PROTOC_ARCH=x86_64 ; fi; \
+    wget -q -O /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-${PROTOC_ARCH}.zip && \
+    unzip -qd /opt/protoc /tmp/protoc.zip && \
+    rm /tmp/protoc.zip && \
+    ln -s /opt/protoc/bin/protoc /usr/bin/
 
 # Create a dummy package
 RUN cargo init /usr/src/abci-app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Tenderdash requires newer protoc version


## What was done?

Bumped protobuf version to 25.2

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
