### PR TITLE
fix(proto)!: wrong json serialization of consensus params

### DIFF
--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -54,7 +54,6 @@ const DERIVE_FROM_STR: &str = r#"#[derive(derive_more::FromStr)]"#;
 /// here: <https://docs.rs/prost-build/0.6.1/prost_build/struct.Config.html#method.btree_map>
 pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.libs.bits.BitArray", SERIALIZED),
-    (".tendermint.types.EvidenceParams", SERIALIZED),
     (".tendermint.types.BlockIDFlag", PRIMITIVE_ENUM),
     (".tendermint.types.Block", SERIALIZED),
     (".tendermint.types.Data", SERIALIZED),

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -91,6 +91,15 @@ pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.crypto.Proof", SERIALIZED),
     (".tendermint.abci.Response.value", DERIVE_FROM),
     (".tendermint.abci.Request.value", DERIVE_FROM),
+    // Consensus params
+    (".tendermint.types.ConsensusParams", SERIALIZED),
+    (".tendermint.types.ABCIParams", SERIALIZED),
+    (".tendermint.types.BlockParams", SERIALIZED),
+    (".tendermint.types.EvidenceParams", SERIALIZED),
+    (".tendermint.types.ValidatorParams", SERIALIZED),
+    (".tendermint.types.VersionParams", SERIALIZED),
+    (".tendermint.types.SynchronyParams", SERIALIZED),
+    (".tendermint.types.TimeoutParams", SERIALIZED),
 ];
 
 /// Custom field attributes applied on top of protobuf fields in (a) struct(s)
@@ -99,10 +108,6 @@ pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
 /// The first item is a path as defined in the prost_build::Config::btree_map
 /// here: <https://docs.rs/prost-build/0.6.1/prost_build/struct.Config.html#method.btree_map>
 pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
-    (
-        ".tendermint.types.EvidenceParams.max_bytes",
-        QUOTED_WITH_DEFAULT,
-    ),
     (".tendermint.version.Consensus.block", QUOTED),
     (".tendermint.version.Consensus.app", QUOTED_WITH_DEFAULT),
     (".tendermint.abci.ResponseInfo.data", DEFAULT),
@@ -200,4 +205,22 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".tendermint.crypto.Proof.total", QUOTED),
     (".tendermint.crypto.Proof.aunts", VEC_BASE64STRING),
     (".tendermint.crypto.Proof.leaf_hash", BASE64STRING),
+    // Consensus params
+    (
+        ".tendermint.types.BlockParams.max_bytes",
+        QUOTED_WITH_DEFAULT,
+    ),
+    (".tendermint.types.BlockParams.max_gas", QUOTED_WITH_DEFAULT),
+    (
+        ".tendermint.types.EvidenceParams.max_age_num_blocks",
+        QUOTED_WITH_DEFAULT,
+    ),
+    (
+        ".tendermint.types.EvidenceParams.max_bytes",
+        QUOTED_WITH_DEFAULT,
+    ),
+    (
+        ".tendermint.types.VersionParams.app_version",
+        QUOTED_WITH_DEFAULT,
+    ),
 ];

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -1,16 +1,20 @@
 //! Serialize and deserialize any `T` that implements [[core::str::FromStr]]
 //! and [[core::fmt::Display]] from or into string. Note this can be used for
 //! all primitive data types.
+#[cfg(not(feature = "std"))]
+use core::{fmt::Display, str::FromStr};
+#[cfg(feature = "std")]
+use std::{fmt::Display, str::FromStr};
+
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::prelude::*;
-
 /// Deserialize string into T
 pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
-    T: core::str::FromStr,
-    <T as core::str::FromStr>::Err: core::fmt::Display,
+    T: FromStr,
+    <T as FromStr>::Err: Display,
 {
     String::deserialize(deserializer)?
         .parse::<T>()
@@ -21,7 +25,7 @@ where
 pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
-    T: core::fmt::Display,
+    T: Display,
 {
     format!("{value}").serialize(serializer)
 }

--- a/proto/src/serializers/time_duration.rs
+++ b/proto/src/serializers/time_duration.rs
@@ -1,5 +1,8 @@
 //! Serialize/deserialize core::time::Duration type from and into string:
+#[cfg(not(feature = "std"))]
 use core::time::Duration;
+#[cfg(feature = "std")]
+use std::time::Duration;
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/proto/src/serializers/timestamp.rs
+++ b/proto/src/serializers/timestamp.rs
@@ -1,6 +1,8 @@
 //! Serialize/deserialize Timestamp type from and into string:
-
+#[cfg(not(feature = "std"))]
 use core::fmt::{self, Debug};
+#[cfg(feature = "std")]
+use std::fmt::{self, Debug};
 
 use serde::{de::Error as _, ser::Error, Deserialize, Deserializer, Serialize, Serializer};
 use time::{
@@ -147,8 +149,8 @@ pub fn to_rfc3339_nanos(t: OffsetDateTime) -> String {
 /// ie. a RFC3339 date-time with left-padded subsecond digits without
 ///     trailing zeros and no trailing dot.
 ///
-/// [`Display`]: core::fmt::Display
-/// [`Debug`]: core::fmt::Debug
+/// [`Display`]: fmt::Display
+/// [`Debug`]: fmt::Debug
 pub fn fmt_as_rfc3339_nanos(t: OffsetDateTime, f: &mut impl fmt::Write) -> fmt::Result {
     let t = t.to_offset(offset!(UTC));
     let nanos = t.nanosecond();

--- a/proto/tests/unit.rs
+++ b/proto/tests/unit.rs
@@ -2,7 +2,7 @@ use core::convert::TryFrom;
 
 use tenderdash_proto::{
     abci::ResponseException,
-    types::{BlockId as RawBlockId, PartSetHeader as RawPartSetHeader},
+    types::{BlockId as RawBlockId, ConsensusParams, PartSetHeader as RawPartSetHeader},
     Protobuf,
 };
 
@@ -132,4 +132,45 @@ pub fn test_response_exception_from() {
         ResponseException::from(&String::from("string")).error,
         "string"
     );
+}
+
+#[test]
+pub fn test_consensus_params_serde() {
+    let json = r#"
+    {
+        "block": {
+          "max_bytes": "2097152",
+          "max_gas": "500000000"
+        },
+        "evidence": {
+          "max_age_num_blocks": "10000",
+          "max_age_duration": "172800000000000",
+          "max_bytes": "0"
+        },
+        "validator": {
+          "pub_key_types": [
+            "bls12381"
+          ]
+        },
+        "version": {
+          "app_version": "1"
+        },
+        "synchrony": {
+          "precision": "500000000",
+          "message_delay": "60000000000"
+        },
+        "timeout": {
+          "propose": "40000000000",
+          "propose_delta": "5000000000",
+          "vote": "40000000000",
+          "vote_delta": "5000000000",
+          "bypass_commit_timeout": true
+        },
+        "abci": {
+          "recheck_tx": true
+        }
+    }
+    "#;
+
+    let _new_params: ConsensusParams = serde_json::from_str(json).unwrap();
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Consensus params serialized to JSON have different format than generated by Tenderdash.

## What was done?

Changed consensus params json verification to match Tenderdash format:

* quoted ints
* duration as nanoseconds

## How Has This Been Tested?

Unit test

## Breaking Changes

Data format of some JSON messages was changed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
