### PR TITLE
fix: tenderdash-proto rebuilt with every run due to changed *.proto

### DIFF
--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -325,3 +325,37 @@ pub(crate) fn tenderdash_commitish() -> String {
         Err(_) => DEFAULT_TENDERDASH_COMMITISH.to_string(),
     }
 }
+
+/// Save the commitish of last successful download to a file in a state file,
+/// located in the `dir` directory and named `download.state`.
+pub(crate) fn save_state(dir: &Path, commitish: &str) {
+    let state_file = PathBuf::from(&dir).join("download.state");
+
+    std::fs::write(&state_file, commitish)
+        .map_err(|e| {
+            println!(
+                "[warn] => Failed to write download.state file {}: {}",
+                state_file.display(),
+                e
+            );
+        })
+        .ok();
+}
+
+/// Check if the state file contains the same commitish as the one we are trying
+/// to download. State file should be located in the `dir` and named
+/// `download.state`
+pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
+    let state_file = PathBuf::from(&dir).join("download.state");
+
+    match read_to_string(&state_file) {
+        Ok(content) => {
+            println!(
+                "[info] => Found previously downloaded Tenderdash {}.",
+               content.trim()
+            );
+            content.eq(commitish)
+        },
+        Err(_) => false,
+    }
+}

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -348,7 +348,7 @@ pub(crate) fn save_state(dir: &Path, commitish: &str) {
 pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
     let state_file = PathBuf::from(&dir).join("download.state");
 
-    match read_to_string(&state_file) {
+    match read_to_string(state_file) {
         Ok(content) => {
             println!(
                 "[info] => Found previously downloaded Tenderdash {}.",

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -352,7 +352,7 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
         Ok(content) => {
             println!(
                 "[info] => Found previously downloaded Tenderdash {}.",
-               content.trim()
+                content.trim()
             );
             content.eq(commitish)
         },

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -1,7 +1,7 @@
 //! This module defines the various errors that be raised during Protobuf
 //! conversions.
 
-use core::{convert::TryFrom, fmt::Display, num::TryFromIntError};
+use core::{fmt::Display, num::TryFromIntError};
 
 use flex_error::{define_error, DisplayOnly};
 use prost::{DecodeError, EncodeError};

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -23,10 +23,7 @@ mod error;
 #[allow(warnings)]
 mod tenderdash;
 
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt::Display,
-};
+use core::fmt::Display;
 
 use bytes::{Buf, BufMut};
 pub use error::Error;

--- a/proto/src/serializers/part_set_header_total.rs
+++ b/proto/src/serializers/part_set_header_total.rs
@@ -5,7 +5,7 @@
 //! from a string-quoted integer value into an integer value without quotes in
 //! Tendermint Core v0.34.0. This deserializer allows backwards-compatibility by
 //! deserializing both ways. See also: <https://github.com/informalsystems/tendermint-rs/issues/679>
-use core::{convert::TryFrom, fmt::Formatter};
+use core::fmt::Formatter;
 
 use serde::{
     de::{Error, Visitor},


### PR DESCRIPTION
## Issue being fixed or feature implemented

tenderdash-proto is rebuilt too often, as with every run it downloads new *.proto files and replaces old ones, affecting timestamps.

## What was done?

Added a state file that records last commitish. If it's the same as current one, proto files are not overwritten.

## How Has This Been Tested?

Locally + GHA, build tenderdash-abci a few times with `-vvv` and observing results.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
