### PR TITLE
fix(proto-compiler): existence of unzipped tenderdash sources not verified correctly

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.14.0-dev.8"
+version = "0.14.0-dev.9"
 name = "tenderdash-abci"
 edition = "2021"
 license = "Apache-2.0"

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.14.0-dev.8"
+version = "0.14.0-dev.9"
 name = "tenderdash-proto-compiler"
 authors = ["Informal Systems <hello@informal.systems>", "Dash Core Group"]
 edition = "2021"

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -350,10 +350,7 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
 
     match read_to_string(state_file) {
         Ok(content) => {
-            println!(
-                "[info] => Found previously downloaded Tenderdash {}.",
-                content.trim()
-            );
+            println!("[info] => Detected Tenderdash version: {}.", content.trim());
             content.eq(commitish)
         },
         Err(_) => false,

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -51,7 +51,8 @@ pub fn proto_compile() {
     let commitish = tenderdash_commitish();
 
     // check if this commitish is already downloaded
-    let download = !check_state(&prost_out_dir, &commitish);
+    let download = std::fs::metadata(tenderdash_dir.join("proto")).is_err()
+        || !check_state(&prost_out_dir, &commitish);
 
     if download {
         println!("[info] => Fetching {TENDERDASH_REPO} at {commitish} into {tenderdash_dir:?}.");

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.14.0-dev.8"
+version = "0.14.0-dev.9"
 name = "tenderdash-proto"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

In some conditions, build of tenderdash-proto fails due to missing version/version.go. It is caused by lack of extracted tenderdash sources.

## What was done?

Re-download and re-extract tenderdash sources if the `proto` directory (which should be extracted from tenderdash sources) is not found.

## How Has This Been Tested?

Run `cargo build -p tenderdash-proto -vvv` a few times (but still needs more testing)


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
