### PR TITLE
fix(proto-compiler): std and no-std generated code conflict

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      # warn when test takes more than 3s, kill after 6s
-      RUST_TEST_TIME_UNIT: "3000,6000"
-      RUST_TEST_TIME_INTEGRATION: "3000,6000"
-      RUST_TEST_TIME_DOCTEST: "3000,6000"
+      # warn when test takes more than 5s, kill after 10s
+      RUST_TEST_TIME_UNIT: "5000,10000"
+      RUST_TEST_TIME_INTEGRATION: "5000,10000"
+      RUST_TEST_TIME_DOCTEST: "5000,10000"
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/deps

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 walkdir = { version = "2.3" }
+prost = { version = "0.12" }
 prost-build = { version = "0.12" }
 tempfile = { version = "3.2.0" }
 regex = { "version" = "1.7.1" }

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 
 [dependencies]
 walkdir = { version = "2.3" }
-prost = { version = "0.12" }
 prost-build = { version = "0.12" }
 tempfile = { version = "3.2.0" }
 regex = { "version" = "1.7.1" }

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -350,7 +350,7 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
 
     let expected = commitish.to_string();
 
-    match read_to_string(&state_file) {
+    match read_to_string(state_file) {
         Ok(content) => {
             println!("[info] => Detected Tenderdash version: {}.", content);
             content == expected

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -51,7 +51,7 @@ pub fn proto_compile(module_name: &str) {
 
     // check if this commitish is already downloaded
     let download = std::fs::metadata(tenderdash_dir.join("proto")).is_err()
-        || !check_state(&prost_out_dir, &commitish, module_name);
+        || !check_state(&prost_out_dir, &commitish);
 
     if download {
         println!("[info] => Fetching {TENDERDASH_REPO} at {commitish} into {tenderdash_dir:?}.");
@@ -128,6 +128,6 @@ pub fn proto_compile(module_name: &str) {
         module_name,
     );
 
-    save_state(&prost_out_dir, &commitish, module_name);
+    save_state(&prost_out_dir, &commitish);
     println!("[info] => Done!");
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -11,7 +11,10 @@ fn main() {
         env::set_var("TENDERDASH_COMMITISH", DEFAULT_VERSION);
     }
 
-    tenderdash_proto_compiler::proto_compile();
+    #[cfg(feature = "std")]
+    tenderdash_proto_compiler::proto_compile("tenderdash_std");
+    #[cfg(not(feature = "std"))]
+    tenderdash_proto_compiler::proto_compile("tenderdash_nostd");
 
     println!("cargo:rerun-if-changed=../proto-compiler/src");
     println!("cargo:rerun-if-changed=Cargo.toml");

--- a/proto/src/.gitignore
+++ b/proto/src/.gitignore
@@ -1,2 +1,6 @@
+tenderdash_nostd/
+tenderdash_std/
+
+# prost/ and tenderdash.rs are deprecated and can be removed in the future
 prost/
 tenderdash.rs

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -20,8 +20,6 @@ pub mod google {
 }
 
 mod error;
-#[allow(warnings)]
-mod tenderdash;
 
 #[cfg(not(feature = "std"))]
 use core::{
@@ -34,12 +32,22 @@ use std::fmt::Display;
 use bytes::{Buf, BufMut};
 pub use error::Error;
 use prost::{encoding::encoded_len_varint, Message};
-pub use tenderdash::*;
+#[cfg(not(feature = "std"))]
+pub mod tenderdash_nostd;
+#[allow(warnings)]
+#[cfg(not(feature = "std"))]
+pub use tenderdash_nostd::*;
+
+#[cfg(feature = "std")]
+#[allow(warnings)]
+pub mod tenderdash_std;
+#[cfg(feature = "std")]
+pub use tenderdash_std::*;
 
 pub mod serializers;
 
+pub use meta::ABCI_VERSION;
 use prelude::*;
-pub use tenderdash::meta::ABCI_VERSION;
 #[cfg(feature = "grpc")]
 pub use tonic;
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -33,11 +33,13 @@ use bytes::{Buf, BufMut};
 pub use error::Error;
 use prost::{encoding::encoded_len_varint, Message};
 #[cfg(not(feature = "std"))]
+#[rustfmt::skip]
 pub mod tenderdash_nostd;
 #[cfg(not(feature = "std"))]
 pub use tenderdash_nostd::*;
 
 #[cfg(feature = "std")]
+#[rustfmt::skip]
 pub mod tenderdash_std;
 #[cfg(feature = "std")]
 pub use tenderdash_std::*;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -34,12 +34,10 @@ pub use error::Error;
 use prost::{encoding::encoded_len_varint, Message};
 #[cfg(not(feature = "std"))]
 pub mod tenderdash_nostd;
-#[allow(warnings)]
 #[cfg(not(feature = "std"))]
 pub use tenderdash_nostd::*;
 
 #[cfg(feature = "std")]
-#[allow(warnings)]
 pub mod tenderdash_std;
 #[cfg(feature = "std")]
 pub use tenderdash_std::*;


### PR DESCRIPTION
## Issue being fixed or feature implemented

When working with both no_std and std (grpc) features,  generated code is not always regenerated.
This can cause issues like including code requiring tonic in no_std mode.

## What was done?

Separated generated code into two modules: tenderdash_std and tenderdash_nostd, which are included/exported using conditional compilation.

## How Has This Been Tested?

Run cargo build with various combinations of features

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
