### PR TITLE
fix: nostd proto not propagated from tenderdash-abci

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.14.0-dev.11"
+version = "0.14.0-dev.12"
 name = "tenderdash-abci"
 edition = "2021"
 license = "Apache-2.0"

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -21,6 +21,7 @@ default = [
     "unix",
     "grpc",
     "tracing-span",
+    "std",
 ]
 # docker-tests includes integration tests that require docker to be available
 docker-tests = ["server"]
@@ -30,8 +31,8 @@ server = [
     "dep:tokio-util",
     "dep:futures",
 ]
-
-grpc = ["tenderdash-proto/grpc"]
+std = ["tenderdash-proto/std"]
+grpc = ["std", "tenderdash-proto/grpc"]
 crypto = ["dep:lhash"]
 tcp = ["server"]
 unix = ["server"]
@@ -43,7 +44,7 @@ required-features = ["server"]
 
 [dependencies]
 uuid = { version = "1.4.1", features = ["v4", "fast-rng"], optional = true }
-tenderdash-proto = { path = "../proto" }
+tenderdash-proto = { path = "../proto", default-features = false }
 bytes = { version = "1.0" }
 prost = { version = "0.12" }
 tracing = { version = "0.1", default-features = false }

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.14.0-dev.11"
+version = "0.14.0-dev.12"
 name = "tenderdash-proto-compiler"
 authors = ["Informal Systems <hello@informal.systems>", "Dash Core Group"]
 edition = "2021"

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -14,7 +14,7 @@ prost-build = { version = "0.12" }
 tempfile = { version = "3.2.0" }
 regex = { "version" = "1.7.1" }
 # Use of native-tls-vendored should build vendored openssl, which is required for Alpine build
-ureq = { "version" = "2.6.2" }
+ureq = { "version" = "2.9.6" }
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 fs_extra = { version = "1.3.0" }
 tonic-build = { version = "0.11.0", optional = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.14.0-dev.11"
+version = "0.14.0-dev.12"
 name = "tenderdash-proto"
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

`default-features=false` on tenderdash-abci should imply `default-features=false` on tenderdash-proto, to build it in nostd mode.

## What was done?

Fixed features in tenderdash-abci
* added "std" feature that enables tenderdash-proto/std
* 

## How Has This Been Tested?

GHA

Built manually using a pet project.

## Breaking Changes
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
