### PR TITLE
fix(proto-compiler): not used no-std proto definitions refer to tonic

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -21,7 +21,6 @@ default = [
     "unix",
     "grpc",
     "tracing-span",
-    "std",
 ]
 # docker-tests includes integration tests that require docker to be available
 docker-tests = ["server"]
@@ -31,8 +30,9 @@ server = [
     "dep:tokio-util",
     "dep:futures",
 ]
-std = ["tenderdash-proto/std"]
-grpc = ["std", "tenderdash-proto/grpc"]
+# std is deprecated, use "grpc" instead
+std = ["grpc"]
+grpc = ["tenderdash-proto/grpc"]
 crypto = ["dep:lhash"]
 tcp = ["server"]
 unix = ["server"]

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -25,7 +25,7 @@ default = []
 # Enable gRPC support; needed by server and client features.
 # Conflicts with no_std
 grpc = ["dep:tonic-build"]
-# Build the gRPC server. Requires tenderdash-proto/std feature.
+# Build the gRPC server. Requires tenderdash-proto/grpc feature.
 server = ["grpc"]
-# Build the gRPC client. Requires tenderdash-proto/std feature.
+# Build the gRPC client. Requires tenderdash-proto/grpc feature.
 client = ["grpc"]

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -3,15 +3,30 @@
 /// Tenderdash repository URL.
 pub const TENDERDASH_REPO: &str = "https://github.com/dashpay/tenderdash";
 
-pub enum ModuleType {
-    Std,
+/// How to generate the protobuf files.
+
+pub enum GenerationMode {
+    /// Generate the files using `tonic` and put them into `tenderdash_grpc`
+    /// module.
+    Grpc,
+    /// Generate the files without `std` and put them into `tenderdash_nostd`
+    /// module.
     NoStd,
 }
-impl ToString for ModuleType {
+impl GenerationMode {
+    pub fn module_name(&self) -> String {
+        match self {
+            GenerationMode::Grpc => "tenderdash_grpc".to_string(),
+            GenerationMode::NoStd => "tenderdash_nostd".to_string(),
+        }
+    }
+}
+
+impl ToString for GenerationMode {
     fn to_string(&self) -> String {
         match self {
-            ModuleType::Std => "tenderdash_std".to_string(),
-            ModuleType::NoStd => "tenderdash_nostd".to_string(),
+            GenerationMode::Grpc => "tonic".to_string(),
+            GenerationMode::NoStd => "nostd".to_string(),
         }
     }
 }

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -2,6 +2,20 @@
 
 /// Tenderdash repository URL.
 pub const TENDERDASH_REPO: &str = "https://github.com/dashpay/tenderdash";
+
+pub enum ModuleType {
+    Std,
+    NoStd,
+}
+impl ToString for ModuleType {
+    fn to_string(&self) -> String {
+        match self {
+            ModuleType::Std => "tenderdash_std".to_string(),
+            ModuleType::NoStd => "tenderdash_nostd".to_string(),
+        }
+    }
+}
+
 // Commitish formats:
 // Tag: v0.34.0-rc4
 // Branch: master

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -7,7 +7,7 @@ use std::{
 
 use walkdir::WalkDir;
 
-use crate::constants::DEFAULT_TENDERDASH_COMMITISH;
+use crate::constants::{ModuleType, DEFAULT_TENDERDASH_COMMITISH};
 
 /// Check out a specific commitish of the tenderdash repository.
 ///
@@ -247,7 +247,7 @@ pub fn generate_tenderdash_lib(
     tenderdash_lib_target: &Path,
     abci_ver: &str,
     td_ver: &str,
-    module_name: &str,
+    module_type: &ModuleType,
 ) {
     let mut file_names = WalkDir::new(prost_dir)
         .into_iter()
@@ -310,7 +310,7 @@ pub mod meta {{
         tenderdash_commitish(),
         abci_ver,
         td_ver,
-        module_name,
+        module_type.to_string(),
     );
 
     let mut file =

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -7,7 +7,7 @@ use std::{
 
 use walkdir::WalkDir;
 
-use crate::constants::{ModuleType, DEFAULT_TENDERDASH_COMMITISH};
+use crate::constants::{GenerationMode, DEFAULT_TENDERDASH_COMMITISH};
 
 /// Check out a specific commitish of the tenderdash repository.
 ///
@@ -247,7 +247,7 @@ pub fn generate_tenderdash_lib(
     tenderdash_lib_target: &Path,
     abci_ver: &str,
     td_ver: &str,
-    module_type: &ModuleType,
+    mode: &GenerationMode,
 ) {
     let mut file_names = WalkDir::new(prost_dir)
         .into_iter()
@@ -301,8 +301,8 @@ pub mod meta {{
     pub const ABCI_VERSION: &str = \"{}\";
     /// Version of Tenderdash server used to generate protobuf configs
     pub const TENDERDASH_VERSION: &str = \"{}\";
-    /// Name of module where generated files are stored; used to distinguish between std and no-std version
-    pub const TENDERDASH_MODULE_NAME: &str = \"{}\";
+    /// Module generation mode
+    pub const TENDERDASH_MODULE_MODE: &str = \"{}\";
 }}
 ",
         content,
@@ -310,7 +310,7 @@ pub mod meta {{
         tenderdash_commitish(),
         abci_ver,
         td_ver,
-        module_type.to_string(),
+        mode.to_string(),
     );
 
     let mut file =

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -9,7 +9,7 @@ use functions::{
 };
 
 mod constants;
-pub use constants::ModuleType;
+pub use constants::GenerationMode;
 use constants::{CUSTOM_FIELD_ATTRIBUTES, CUSTOM_TYPE_ATTRIBUTES, TENDERDASH_REPO};
 
 use crate::functions::{check_state, save_state};
@@ -23,14 +23,14 @@ use crate::functions::{check_state, save_state};
 /// # Arguments
 ///
 /// * `module_name` - name of module to put generated files into
-pub fn proto_compile(module_type: ModuleType) {
+pub fn proto_compile(mode: GenerationMode) {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     let prost_out_dir = root
         .join("..")
         .join("proto")
         .join("src")
-        .join(module_type.to_string());
+        .join(mode.module_name());
     let tenderdash_lib_target = prost_out_dir.join("mod.rs");
 
     let out_dir = var("OUT_DIR")
@@ -113,20 +113,17 @@ pub fn proto_compile(module_type: ModuleType) {
 
     println!("[info] => Creating structs.");
 
-    match module_type {
-        ModuleType::Std => {
+    match mode {
+        GenerationMode::Grpc => {
             #[cfg(feature = "grpc")]
             tonic_build::configure()
                 .generate_default_stubs(true)
                 .compile_with_config(pb, &protos, &proto_includes_paths)
                 .unwrap();
             #[cfg(not(feature = "grpc"))]
-            panic!(
-                "grpc feature is required to compile {}",
-                module_type.to_string()
-            );
+            panic!("grpc feature is required to compile {}", mode.to_string());
         },
-        ModuleType::NoStd => {
+        GenerationMode::NoStd => {
             pb.compile_protos(&protos, &proto_includes_paths).unwrap();
         },
     }
@@ -139,7 +136,7 @@ pub fn proto_compile(module_type: ModuleType) {
         &tenderdash_lib_target,
         &abci_ver,
         &tenderdash_ver,
-        &module_type,
+        &mode,
     );
 
     save_state(&prost_out_dir, &commitish);

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -33,11 +33,12 @@ all-features = true
 # issues related to outdated generated files.
 default = ["grpc"]
 
-# Enable standard library support
-std = ["prost/std", "prost-types/std"]
-# Build gRPC server
+# Enable standard library support; DEPRECATED - use `grpc` instead
+std = ["grpc"]
+# Build gRPC server using tonic
 grpc = [
-    "std",
+    "prost/std",
+    "prost-types/std",
     "tenderdash-proto-compiler/server",
     "tenderdash-proto-compiler/client",
     "dep:tonic",

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use tenderdash_proto_compiler::ModuleType;
+
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
     const DEFAULT_VERSION: &str = "v0.14.0-dev.5";
@@ -11,10 +13,10 @@ fn main() {
         env::set_var("TENDERDASH_COMMITISH", DEFAULT_VERSION);
     }
 
-    #[cfg(feature = "std")]
-    tenderdash_proto_compiler::proto_compile("tenderdash_std");
-    #[cfg(not(feature = "std"))]
-    tenderdash_proto_compiler::proto_compile("tenderdash_nostd");
+    #[cfg(feature = "grpc")]
+    tenderdash_proto_compiler::proto_compile(ModuleType::Std);
+    // we always build nostd version
+    tenderdash_proto_compiler::proto_compile(ModuleType::NoStd);
 
     println!("cargo:rerun-if-changed=../proto-compiler/src");
     println!("cargo:rerun-if-changed=Cargo.toml");

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use tenderdash_proto_compiler::ModuleType;
+use tenderdash_proto_compiler::GenerationMode;
 
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
@@ -14,9 +14,9 @@ fn main() {
     }
 
     #[cfg(feature = "grpc")]
-    tenderdash_proto_compiler::proto_compile(ModuleType::Std);
+    tenderdash_proto_compiler::proto_compile(GenerationMode::Grpc);
     // we always build nostd version
-    tenderdash_proto_compiler::proto_compile(ModuleType::NoStd);
+    tenderdash_proto_compiler::proto_compile(GenerationMode::NoStd);
 
     println!("cargo:rerun-if-changed=../proto-compiler/src");
     println!("cargo:rerun-if-changed=Cargo.toml");

--- a/proto/src/.gitignore
+++ b/proto/src/.gitignore
@@ -1,5 +1,5 @@
 tenderdash_nostd/
-tenderdash_std/
+tenderdash_grpc/
 
 # prost/ and tenderdash.rs are deprecated and can be removed in the future
 prost/

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -1,8 +1,8 @@
 //! This module defines the various errors that be raised during Protobuf
 //! conversions.
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::{convert::TryFrom, fmt::Display, num::TryFromIntError};
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::{fmt::Display, num::TryFromIntError};
 
 use flex_error::{define_error, DisplayOnly};

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -40,9 +40,9 @@ pub use tenderdash_nostd::*;
 
 #[cfg(feature = "grpc")]
 #[rustfmt::skip]
-pub mod tenderdash_std;
+pub mod tenderdash_grpc;
 #[cfg(feature = "grpc")]
-pub use tenderdash_std::*;
+pub use tenderdash_grpc::*;
 
 pub mod serializers;
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,7 +1,7 @@
 //! tenderdash-proto library gives the developer access to the Tenderdash
 //! proto-defined structs.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "grpc"), no_std)]
 #![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant)]
 #![forbid(unsafe_code)]
@@ -21,27 +21,27 @@ pub mod google {
 
 mod error;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::{
     convert::{TryFrom, TryInto},
     fmt::Display,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::fmt::Display;
 
 use bytes::{Buf, BufMut};
 pub use error::Error;
 use prost::{encoding::encoded_len_varint, Message};
-#[cfg(not(feature = "std"))]
 #[rustfmt::skip]
 pub mod tenderdash_nostd;
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
+// Re-export the nostd module only if the std one is not available
 pub use tenderdash_nostd::*;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 #[rustfmt::skip]
 pub mod tenderdash_std;
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 pub use tenderdash_std::*;
 
 pub mod serializers;

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -3,9 +3,9 @@
 // Prost does not seem to have a way yet to remove documentations defined in
 // protobuf files. These structs are defined in gogoproto v1.3.1 at https://github.com/gogo/protobuf/tree/v1.3.1/protobuf/google/protobuf
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::fmt;
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::fmt;
 
 /// A Timestamp represents a point in time independent of any time zone or local

--- a/proto/src/serializers/from_str.rs
+++ b/proto/src/serializers/from_str.rs
@@ -1,9 +1,9 @@
 //! Serialize and deserialize any `T` that implements [[core::str::FromStr]]
 //! and [[core::fmt::Display]] from or into string. Note this can be used for
 //! all primitive data types.
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::{fmt::Display, str::FromStr};
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::{fmt::Display, str::FromStr};
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};

--- a/proto/src/serializers/part_set_header_total.rs
+++ b/proto/src/serializers/part_set_header_total.rs
@@ -6,9 +6,9 @@
 //! Tendermint Core v0.34.0. This deserializer allows backwards-compatibility by
 //! deserializing both ways. See also: <https://github.com/informalsystems/tendermint-rs/issues/679>
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::{convert::TryFrom, fmt::Formatter};
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::fmt::Formatter;
 
 use serde::{

--- a/proto/src/serializers/time_duration.rs
+++ b/proto/src/serializers/time_duration.rs
@@ -1,7 +1,7 @@
 //! Serialize/deserialize core::time::Duration type from and into string:
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::time::Duration;
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::time::Duration;
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};

--- a/proto/src/serializers/timestamp.rs
+++ b/proto/src/serializers/timestamp.rs
@@ -1,7 +1,7 @@
 //! Serialize/deserialize Timestamp type from and into string:
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::fmt::{self, Debug};
-#[cfg(feature = "std")]
+#[cfg(feature = "grpc")]
 use std::fmt::{self, Debug};
 
 use serde::{de::Error as _, ser::Error, Deserialize, Deserializer, Serialize, Serializer};

--- a/proto/tests/unit.rs
+++ b/proto/tests/unit.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "grpc"))]
 use core::convert::TryFrom;
 
 use tenderdash_proto::{


### PR DESCRIPTION
## Issue being fixed or feature implemented

After building it multiple times, tenderdash_nostd  sometimes refers to tonic which is unavailable due to changed features.
This impacts IDE which shows false errors, etc.

## What was done?

* deprecate "std" feature in favor of "grpc" feature ("std" is using tonic anyway)
* always build nostd, but don't re-export it in "grpc" mode
* in proto-compiler, build grpc based on func argument, not based on feature
* renamed module "tenderdash_std" to "tenderdash_grpc"

## How Has This Been Tested?

Run `cargo build --no-default-features` and `cargo build --no-default-features -F grpc` multiple times in various combinations to ensure it works

## Breaking Changes

* "std" feature is deprecated but in backwards-compatible way
* renamed module `tendedash_proto::tenderdash_std` to `tendedash_proto::tenderdash_grpc`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
