### PR TITLE
feat(proto-compiler): check required protoc version before build

### DIFF
--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -1,5 +1,8 @@
 //! Tenderdash protobuf implementation
 
+// Requirements
+pub const DEP_PROTOC_VERSION: f32 = 25.0;
+
 /// Tenderdash repository URL.
 pub const TENDERDASH_REPO: &str = "https://github.com/dashpay/tenderdash";
 

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -381,7 +381,7 @@ fn dep_protoc(expected_version: f32) -> Result<f32, String> {
     let protoc = prost_build::protoc_from_env();
 
     // Run `protoc --version` and capture the output
-    let output = Command::new(&protoc)
+    let output = Command::new(protoc)
         .arg("--version")
         .output()
         .map_err(|e| format!("failed to run: {}", e))?;
@@ -389,7 +389,7 @@ fn dep_protoc(expected_version: f32) -> Result<f32, String> {
     // Convert the output to a string
     let out = output.stdout;
     let version_output = String::from_utf8(out.clone())
-        .map_err(|e| format!("output {:?} is not utf8 string: {}", out, e.to_string()))?;
+        .map_err(|e| format!("output {:?} is not utf8 string: {}", out, e))?;
 
     // Extract the version number from string like `libprotoc 25.1`
     let version: f32 = version_output

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -362,18 +362,7 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
 
 /// Check if all dependencies are met
 pub(crate) fn check_deps() -> Result<(), String> {
-    // Check if the required
-    let mut errors = vec![];
-
-    if let Err(e) = dep_protoc(DEP_PROTOC_VERSION) {
-        errors.push(format!("protoc: {}", e));
-    };
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors.join("\n"))
-    }
+    dep_protoc(DEP_PROTOC_VERSION).map(|_| ())
 }
 
 /// Check if protoc is installed and has the required version

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -399,7 +399,6 @@ fn dep_protoc(expected_version: f32) -> Result<f32, String> {
         .parse()
         .map_err(|e| format!("failed to parse protoc version {}: {}", version_output, e))?;
 
-    // Check if the version is equal or higher than 25.1
     if version < expected_version {
         Err(format!(
             "protoc version must be {} or higher, but found {}; please upgrade: https://github.com/protocolbuffers/protobuf/releases/",

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -12,7 +12,7 @@ mod constants;
 pub use constants::GenerationMode;
 use constants::{CUSTOM_FIELD_ATTRIBUTES, CUSTOM_TYPE_ATTRIBUTES, TENDERDASH_REPO};
 
-use crate::functions::{check_state, save_state};
+use crate::functions::{check_deps, check_state, save_state};
 
 /// Import and compile protobuf definitions for Tenderdash.
 ///
@@ -53,6 +53,12 @@ pub fn proto_compile(mode: GenerationMode) {
     let thirdparty_dir = root.join("third_party");
 
     let commitish = tenderdash_commitish();
+
+    // ensure dependencies are up to date
+    if let Err(e) = check_deps() {
+        eprintln!("[error] => {}", e);
+        std::process::exit(1);
+    }
 
     // check if this commitish is already downloaded
     let download = std::fs::metadata(tenderdash_dir.join("proto")).is_err()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

In Ubuntu, protoc compiler is too old, and users don't know how to solve that

## What was done?

Added version detection


## How Has This Been Tested?

Modify `const DEP_PROTOC_VERSION` and run `cargo build -p tenderdash-proto` a few times.


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
