### PR TITLE
test(abci): fix tokio spawning in grpc test

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -87,3 +87,4 @@ hex = { version = "0.4.3" }
 lazy_static = { version = "1.4.0" }
 # For tests of gRPC server
 tonic = { version = "0.11.0" }
+pollster = { version = "0.3.0" }

--- a/abci/tests/grpc.rs
+++ b/abci/tests/grpc.rs
@@ -113,10 +113,7 @@ async fn grpc_server_test(test_name: &str, bind_address: &str) {
         }
     }
 
-    tokio::task::spawn_blocking(move || drop(td))
-        .await
-        .expect("tenderdash cleanup");
-
+    drop(td);
     tracing::info!("Test finished successfully");
 }
 

--- a/abci/tests/grpc.rs
+++ b/abci/tests/grpc.rs
@@ -21,7 +21,7 @@ use tenderdash_abci::proto;
 use tonic::{async_trait, Response, Status};
 
 #[cfg(feature = "docker-tests")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 /// Test server listening on ipv4 address.
 ///
 /// See [tcp_server_test()].
@@ -34,7 +34,7 @@ async fn test_ipv4_server() {
 }
 
 #[cfg(feature = "docker-tests")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "IPv6 does not work for gRPC, most likely bug on Tenderdash side"]
 /// Test server listening on ipv6 address.
 ///
@@ -74,7 +74,7 @@ async fn grpc_server_test(test_name: &str, bind_address: &str) {
     let addr = bind_address.parse().expect("address must be valid");
     let server_cancel = cancel.clone();
     let server_handle = tokio::spawn(async move {
-        tracing::debug!("starting gRPC server");
+        tracing::debug!(?addr, "starting gRPC server");
         Server::builder()
             .add_service(AbciApplicationServer::new(app))
             .serve_with_shutdown(addr, server_cancel.cancelled())
@@ -87,7 +87,7 @@ async fn grpc_server_test(test_name: &str, bind_address: &str) {
     let container_name = format!("tenderdash_{}", test_name);
 
     let td = tokio::task::spawn_blocking(move || {
-        tracing::debug!("starting Tenderdash in Docker container");
+        tracing::debug!(addr=?socket_uri, "starting Tenderdash in Docker container");
         let td = Arc::new(common::docker::TenderdashDocker::new(
             &container_name,
             None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Cannot create new tokio runtime inside a runtime. This means that block_on() cannot be used.

## What was done?

Use tokio::spawn() together with pollster in tests to workaround the issue.

## How Has This Been Tested?

Run tests locally.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
