### PR TITLE
build(proto): update zip and remove unused prost_type dep

### DIFF
--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -15,7 +15,7 @@ tempfile = { version = "3.10.1" }
 regex = { "version" = "1.10.4" }
 # Use of native-tls-vendored should build vendored openssl, which is required for Alpine build
 ureq = { "version" = "2.9.6" }
-zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
 fs_extra = { version = "1.3.0" }
 tonic-build = { version = "0.11.0", optional = true }
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -38,7 +38,6 @@ std = ["grpc"]
 # Build gRPC server using tonic
 grpc = [
     "prost/std",
-    "prost-types/std",
     "tenderdash-proto-compiler/server",
     "tenderdash-proto-compiler/client",
     "dep:tonic",
@@ -48,7 +47,6 @@ grpc = [
 prost = { version = "0.12.4", default-features = false, features = [
     "prost-derive",
 ] }
-prost-types = { version = "0.12.4", default-features = false }
 tonic = { version = "0.11.0", optional = true }
 bytes = { version = "1.6.0", default-features = false, features = ["serde"] }
 serde = { version = "1.0.197", default-features = false, features = ["derive"] }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

* very old version of zip crate in use by proto-compiler
* unused prost_types in use by proto


## What was done?

update zip t 2.1.3, remove prost_types


## How Has This Been Tested?

GHA

```
cargo check --no-default-features
cargo check --no-default-features -F grpc
cargo check --no-default-features -F std
```

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
