### PR TITLE
chore: release rs-tenderdash-abci 1.1.0-dev.1 for TD 1.1.0-dev.3+

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "1.0.0"
+version = "1.1.0-dev.1"
 name = "tenderdash-abci"
 edition = "2021"
 license = "Apache-2.0"

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "1.0.0"
+version = "1.1.0-dev.1"
 name = "tenderdash-proto-compiler"
 authors = ["Informal Systems <hello@informal.systems>", "Dash Core Group"]
 edition = "2021"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "1.0.0"
+version = "1.1.0-dev.1"
 name = "tenderdash-proto"
 edition = "2021"
 license = "Apache-2.0"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -4,7 +4,7 @@ use tenderdash_proto_compiler::GenerationMode;
 
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
-    const DEFAULT_VERSION: &str = "v1.0.0";
+    const DEFAULT_VERSION: &str = "v1.1.0-dev.3";
 
     // check if TENDERDASH_COMMITISH is already set; if not, set it to the current
     // version


### PR DESCRIPTION
## Issue being fixed or feature implemented

Update for new version of Tenderdash ABCI protocol (1.1.0), introduced in Tenderdash 1.1.0-dev.3


## What was done?

* update version to 1.1.0-dev.1
* use tenderdash 1.1.0-dev.3 as source of protobuf definitions and test images


## How Has This Been Tested?

GH Actions


## Breaking Changes

Requires ABCI version 1.1.0+


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
