### PR TITLE
feat(proto)!: serde feature to enable serde for all messages

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -40,6 +40,7 @@ crypto = ["dep:lhash"]
 tcp = ["server"]
 unix = ["server"]
 tracing-span = ["dep:uuid"]
+serde = ["tenderdash-proto/serde", "dep:serde_json"]
 
 [[example]]
 name = "echo_socket"
@@ -47,16 +48,14 @@ required-features = ["server"]
 
 [dependencies]
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"], optional = true }
-tenderdash-proto = { path = "../proto", default-features = false, features = [
-    "serde",
-] }
+tenderdash-proto = { path = "../proto", default-features = false }
 bytes = { version = "1.6.0" }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", optional = true, default-features = false, features = [
     "ansi",
     "env-filter",
 ] }
-serde_json = "1.0.115"
+serde_json = { version = "1.0.128", optional = true }
 thiserror = { version = "1.0.58" }
 url = { version = "2.5.0" }
 semver = { version = "1.0.22" }

--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -44,7 +44,9 @@ required-features = ["server"]
 
 [dependencies]
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"], optional = true }
-tenderdash-proto = { path = "../proto", default-features = false }
+tenderdash-proto = { path = "../proto", default-features = false, features = [
+    "serde",
+] }
 bytes = { version = "1.6.0" }
 prost = { version = "0.12.4" }
 tracing = { version = "0.1.40", default-features = false }

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -43,40 +43,46 @@ pub(crate) const DEFAULT_TENDERDASH_COMMITISH: &str = "v0.10-dev";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;
-const SERIALIZED: &str = r#"#[derive(::serde::Deserialize, ::serde::Serialize)]"#;
-const TYPE_TAG: &str = r#"#[serde(tag = "type", content = "value")]"#;
+pub(crate) const SERIALIZED: &str =
+    r#"#[cfg_attr(feature = "serde", derive(::serde::Deserialize, ::serde::Serialize))]"#;
+const TYPE_TAG: &str = r#"#[cfg_attr(feature = "serde", serde(tag = "type", content = "value"))]"#;
 /// Predefined custom attributes for field annotations
-const QUOTED: &str = r#"#[serde(with = "crate::serializers::from_str")]"#;
-const QUOTED_WITH_DEFAULT: &str = r#"#[serde(with = "crate::serializers::from_str", default)]"#;
-const DEFAULT: &str = r#"#[serde(default)]"#;
-const HEXSTRING: &str = r#"#[serde(with = "crate::serializers::bytes::hexstring")]"#;
-const BASE64STRING: &str = r#"#[serde(with = "crate::serializers::bytes::base64string")]"#;
-const VEC_BASE64STRING: &str = r#"#[serde(with = "crate::serializers::bytes::vec_base64string")]"#;
-const OPTIONAL: &str = r#"#[serde(with = "crate::serializers::optional")]"#;
+const QUOTED: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::from_str"))]"#;
+const QUOTED_WITH_DEFAULT: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::from_str", default))]"#;
+const DEFAULT: &str = r#"#[cfg_attr(feature = "serde", serde(default))]"#;
+const HEXSTRING: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::bytes::hexstring"))]"#;
+const BASE64STRING: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::bytes::base64string"))]"#;
+const VEC_BASE64STRING: &str = r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::bytes::vec_base64string"))]"#;
+const OPTIONAL: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::optional"))]"#;
 // const BYTES_SKIP_IF_EMPTY: &str = r#"#[serde(skip_serializing_if =
 // "bytes::Bytes::is_empty")]"#;
 const DERIVE_FROM_FORWARD: &str = r#"#[from(forward)]"#;
-const NULLABLEVECARRAY: &str = r#"#[serde(with = "crate::serializers::txs")]"#;
-const NULLABLE: &str = r#"#[serde(with = "crate::serializers::nullable")]"#;
-const ALIAS_POWER_QUOTED: &str =
-    r#"#[serde(alias = "power", with = "crate::serializers::from_str")]"#;
+const NULLABLEVECARRAY: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::txs"))]"#;
+const NULLABLE: &str =
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::nullable"))]"#;
+const ALIAS_POWER_QUOTED: &str = r#"#[cfg_attr(feature = "serde", serde(alias = "power", with = "crate::serializers::from_str"))]"#;
 const PART_SET_HEADER_TOTAL: &str =
-    r#"#[serde(with = "crate::serializers::part_set_header_total")]"#;
-const RENAME_EDPUBKEY: &str = r#"#[serde(rename = "tenderdash/PubKeyEd25519", with = "crate::serializers::bytes::base64string")]"#;
-const RENAME_SECPPUBKEY: &str = r#"#[serde(rename = "tenderdash/PubKeySecp256k1", with = "crate::serializers::bytes::base64string")]"#;
-const RENAME_SRPUBKEY: &str = r#"#[serde(rename = "tenderdash/PubKeySr25519", with = "crate::serializers::bytes::base64string")]"#;
-const RENAME_DUPLICATEVOTE: &str = r#"#[serde(rename = "tenderdash/DuplicateVoteEvidence")]"#;
+    r#"#[cfg_attr(feature = "serde", serde(with = "crate::serializers::part_set_header_total"))]"#;
+const RENAME_EDPUBKEY: &str = r#"#[cfg_attr(feature = "serde", serde(rename = "tenderdash/PubKeyEd25519", with = "crate::serializers::bytes::base64string"))]"#;
+const RENAME_SECPPUBKEY: &str = r#"#[cfg_attr(feature = "serde", serde(rename = "tenderdash/PubKeySecp256k1", with = "crate::serializers::bytes::base64string"))]"#;
+const RENAME_SRPUBKEY: &str = r#"#[cfg_attr(feature = "serde", serde(rename = "tenderdash/PubKeySr25519", with = "crate::serializers::bytes::base64string"))]"#;
+const RENAME_DUPLICATEVOTE: &str =
+    r#"#[cfg_attr(feature = "serde", serde(rename = "tenderdash/DuplicateVoteEvidence"))]"#;
 const RENAME_LIGHTCLIENTATTACK: &str =
-    r#"#[serde(rename = "tenderdash/LightClientAttackEvidence")]"#;
+    r#"#[cfg_attr(feature = "serde", serde(rename = "tenderdash/LightClientAttackEvidence"))]"#;
 // const EVIDENCE_VARIANT: &str = r#"#[serde(from =
 // "crate::serializers::evidence::EvidenceVariant",
 // into = "crate::serializers::evidence::EvidenceVariant")]"#;
-const ALIAS_VALIDATOR_POWER_QUOTED: &str =
-    r#"#[serde(alias = "ValidatorPower", with = "crate::serializers::from_str")]"#;
-const ALIAS_TOTAL_VOTING_POWER_QUOTED: &str =
-    r#"#[serde(alias = "TotalVotingPower", with = "crate::serializers::from_str")]"#;
-const ALIAS_TIMESTAMP: &str = r#"#[serde(alias = "Timestamp")]"#;
-const ALIAS_PARTS: &str = r#"#[serde(alias = "parts")]"#;
+const ALIAS_VALIDATOR_POWER_QUOTED: &str = r#"#[cfg_attr(feature = "serde", serde(alias = "ValidatorPower", with = "crate::serializers::from_str"))]"#;
+const ALIAS_TOTAL_VOTING_POWER_QUOTED: &str = r#"#[cfg_attr(feature = "serde", serde(alias = "TotalVotingPower", with = "crate::serializers::from_str"))]"#;
+const ALIAS_TIMESTAMP: &str = r#"#[cfg_attr(feature = "serde", serde(alias = "Timestamp"))]"#;
+const ALIAS_PARTS: &str = r#"#[cfg_attr(feature = "serde", serde(alias = "parts"))]"#;
 const DERIVE_FROM: &str = r#"#[derive(derive_more::From)]"#;
 const DERIVE_FROM_STR: &str = r#"#[derive(derive_more::FromStr)]"#;
 /// Custom type attributes applied on top of protobuf structs
@@ -85,54 +91,13 @@ const DERIVE_FROM_STR: &str = r#"#[derive(derive_more::FromStr)]"#;
 /// The first item is a path as defined in the prost_build::Config::btree_map
 /// here: <https://docs.rs/prost-build/0.6.1/prost_build/struct.Config.html#method.btree_map>
 pub static CUSTOM_TYPE_ATTRIBUTES: &[(&str, &str)] = &[
-    (".tendermint.abci.Event", SERIALIZED),
-    (".tendermint.abci.EventAttribute", SERIALIZED),
-    (".tendermint.libs.bits.BitArray", SERIALIZED),
-    (".tendermint.types.BlockIDFlag", PRIMITIVE_ENUM),
-    (".tendermint.types.Block", SERIALIZED),
-    (".tendermint.types.Data", SERIALIZED),
-    (".tendermint.types.EvidenceList", SERIALIZED),
-    (".tendermint.types.Evidence", SERIALIZED),
-    (".tendermint.types.EvidenceVariant", SERIALIZED),
-    (".tendermint.types.DuplicateVoteEvidence", SERIALIZED),
-    (".tendermint.types.Vote", SERIALIZED),
-    (".tendermint.types.BlockID", SERIALIZED),
-    (".tendermint.types.PartSetHeader", SERIALIZED),
-    (".tendermint.types.LightClientAttackEvidence", SERIALIZED),
-    (".tendermint.types.LightBlock", SERIALIZED),
-    (".tendermint.types.SignedHeader", SERIALIZED),
-    (".tendermint.types.Header", SERIALIZED),
-    (".tendermint.version.Consensus", SERIALIZED),
-    (".tendermint.types.Commit", SERIALIZED),
-    (".tendermint.types.CommitSig", SERIALIZED),
-    (".tendermint.types.CoreChainLock", SERIALIZED),
-    (".tendermint.types.ValidatorSet", SERIALIZED),
-    (".tendermint.crypto.PublicKey", SERIALIZED),
     (".tendermint.crypto.PublicKey.sum", TYPE_TAG),
+    (".tendermint.types.BlockIDFlag", PRIMITIVE_ENUM),
     (".tendermint.types.Evidence.sum", TYPE_TAG),
-    (".tendermint.abci.ResponseInfo", SERIALIZED),
+    (".tendermint.abci.Request.value", DERIVE_FROM),
+    (".tendermint.abci.Response.value", DERIVE_FROM),
     (".tendermint.abci.ResponseException", DERIVE_FROM),
     (".tendermint.abci.ResponseException", DERIVE_FROM_STR),
-    (".tendermint.types.CanonicalBlockID", SERIALIZED),
-    (".tendermint.types.CanonicalPartSetHeader", SERIALIZED),
-    (".tendermint.types.Validator", SERIALIZED),
-    (".tendermint.types.CanonicalVote", SERIALIZED),
-    (".tendermint.types.VoteExtension", SERIALIZED),
-    (".tendermint.types.BlockMeta", SERIALIZED),
-    // (".tendermint.types.Evidence", EVIDENCE_VARIANT),
-    (".tendermint.types.TxProof", SERIALIZED),
-    (".tendermint.crypto.Proof", SERIALIZED),
-    (".tendermint.abci.Response.value", DERIVE_FROM),
-    (".tendermint.abci.Request.value", DERIVE_FROM),
-    // Consensus params
-    (".tendermint.types.ConsensusParams", SERIALIZED),
-    (".tendermint.types.ABCIParams", SERIALIZED),
-    (".tendermint.types.BlockParams", SERIALIZED),
-    (".tendermint.types.EvidenceParams", SERIALIZED),
-    (".tendermint.types.ValidatorParams", SERIALIZED),
-    (".tendermint.types.VersionParams", SERIALIZED),
-    (".tendermint.types.SynchronyParams", SERIALIZED),
-    (".tendermint.types.TimeoutParams", SERIALIZED),
 ];
 
 /// Custom field attributes applied on top of protobuf fields in (a) struct(s)

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -128,7 +128,7 @@ pub fn proto_compile(mode: GenerationMode) {
             #[cfg(feature = "grpc")]
             tonic_build::configure()
                 .generate_default_stubs(true)
-                .compile_with_config(pb, &protos, &proto_includes_paths)
+                .compile_protos_with_config(pb, &protos, &proto_includes_paths)
                 .unwrap();
             #[cfg(not(feature = "grpc"))]
             panic!("grpc feature is required to compile {}", mode.to_string());

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -95,10 +95,14 @@ pub fn proto_compile(mode: GenerationMode) {
 
     // Compile proto files with added annotations, exchange prost_types to our own
     pb.out_dir(&out_dir);
+    pb.type_attribute(".", constants::SERIALIZED);
     for type_attribute in CUSTOM_TYPE_ATTRIBUTES {
+        println!("[info] => Adding type attribute: {:?}", type_attribute);
         pb.type_attribute(type_attribute.0, type_attribute.1);
     }
+
     for field_attribute in CUSTOM_FIELD_ATTRIBUTES {
+        println!("[info] => Adding field attribute: {:?}", field_attribute);
         pb.field_attribute(field_attribute.0, field_attribute.1);
     }
     // The below in-place path redirection replaces references to the Duration

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 #
 # Sometimes cleaning the build cache with `cargo clean` might be necessary to solve
 # issues related to outdated generated files.
-default = ["grpc", "serde"]
+default = ["grpc"]
 
 # Enable standard library support; DEPRECATED - use `grpc` instead
 std = ["grpc"]

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 #
 # Sometimes cleaning the build cache with `cargo clean` might be necessary to solve
 # issues related to outdated generated files.
-default = ["grpc"]
+default = ["grpc", "serde"]
 
 # Enable standard library support; DEPRECATED - use `grpc` instead
 std = ["grpc"]
@@ -43,13 +43,17 @@ grpc = [
     "dep:tonic",
 ]
 
+serde = ["dep:serde", "bytes/serde"]
+
 [dependencies]
+bytes = { version = "1.6.0", default-features = false }
 prost = { version = "0.12.4", default-features = false, features = [
     "prost-derive",
 ] }
 tonic = { version = "0.11.0", optional = true }
-bytes = { version = "1.6.0", default-features = false, features = ["serde"] }
-serde = { version = "1.0.197", default-features = false, features = ["derive"] }
+serde = { version = "1.0.197", default-features = false, features = [
+    "derive",
+], optional = true }
 subtle-encoding = { version = "0.5.1", default-features = false, features = [
     "hex",
     "base64",

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -12,6 +12,11 @@ use crate::prelude::*;
 
 define_error! {
     Error {
+        TimeConversion
+            { reason: String }
+            | e | {
+            format!("error converting time: {}", e.reason)
+        },
         TryFromProtobuf
             { reason: String }
             | e | {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -45,6 +45,7 @@ pub mod tenderdash_grpc;
 pub use tenderdash_grpc::*;
 
 pub mod serializers;
+mod time;
 
 pub use meta::ABCI_VERSION;
 use prelude::*;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -49,9 +49,7 @@ pub mod serializers;
 mod time;
 
 pub use meta::ABCI_VERSION;
-use prelude::*;
-#[cfg(feature = "grpc")]
-pub use tonic;
+pub use prelude::*;
 
 /// Allows for easy Google Protocol Buffers encoding and decoding of domain
 /// types with validation.

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -43,7 +43,7 @@ pub use tenderdash_nostd::*;
 pub mod tenderdash_grpc;
 #[cfg(feature = "grpc")]
 pub use tenderdash_grpc::*;
-
+#[cfg(feature = "serde")]
 pub mod serializers;
 mod time;
 

--- a/proto/src/prelude.rs
+++ b/proto/src/prelude.rs
@@ -1,6 +1,6 @@
 // Re-export according to alloc::prelude::v1 because it is not yet stabilized
 // https://doc.rust-lang.org/src/alloc/prelude/v1.rs.html
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 pub use alloc::{
     borrow::ToOwned,
     boxed::Box,
@@ -11,5 +11,7 @@ pub use alloc::{
 };
 pub use core::prelude::v1::*;
 
-#[allow(unused_imports)]
+#[cfg(feature = "grpc")]
+pub use tonic;
+
 pub use crate::time::{FromMillis, ToMillis};

--- a/proto/src/prelude.rs
+++ b/proto/src/prelude.rs
@@ -10,3 +10,6 @@ pub use alloc::{
     vec::Vec,
 };
 pub use core::prelude::v1::*;
+
+#[allow(unused_imports)]
+pub use crate::time::{FromMillis, ToMillis};

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -21,10 +21,14 @@ use std::fmt;
 /// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
 /// restricting to that range, we ensure that we can convert to and from [RFC
 /// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
-#[derive(Clone, PartialEq, ::prost::Message, ::serde::Deserialize, ::serde::Serialize)]
-#[serde(
-    from = "crate::serializers::timestamp::Rfc3339",
-    into = "crate::serializers::timestamp::Rfc3339"
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(
+        from = "crate::serializers::timestamp::Rfc3339",
+        into = "crate::serializers::timestamp::Rfc3339"
+    )
 )]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
@@ -62,7 +66,7 @@ pub struct Duration {
     #[prost(int32, tag = "2")]
     pub nanos: i32,
 }
-
+#[cfg(feature = "serde")]
 impl serde::Serialize for Duration {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -72,9 +76,9 @@ impl serde::Serialize for Duration {
         serializer.serialize_i64(total_nanos)
     }
 }
-
+#[cfg(feature = "serde")]
 struct DurationVisitor;
-
+#[cfg(feature = "serde")]
 impl<'de> serde::de::Visitor<'de> for DurationVisitor {
     type Value = Duration;
 
@@ -99,7 +103,7 @@ impl<'de> serde::de::Visitor<'de> for DurationVisitor {
         self.visit_i128(value)
     }
 }
-
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Duration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/proto/src/serializers/timestamp.rs
+++ b/proto/src/serializers/timestamp.rs
@@ -29,67 +29,11 @@ impl From<Rfc3339> for Timestamp {
     }
 }
 
-pub trait ToMilis {
-    /// Convert protobuf timestamp into miliseconds since epoch
-
-    /// Note there is a resolution difference, as timestamp uses nanoseconds
-    ///
-    /// # Arguments
-    ///
-    /// * millis - time since epoch, in miliseconds
-    ///
-    /// # Panics
-    ///  
-    /// Panics when timestamp doesn't fit `u64` type
-    fn to_milis(&self) -> u64;
-}
-
-impl ToMilis for Timestamp {
-    /// Convert protobuf timestamp into miliseconds since epoch
-    fn to_milis(&self) -> u64 {
-        chrono::DateTime::from_timestamp(self.seconds, self.nanos as u32)
-            .unwrap()
-            .to_utc()
-            .timestamp_millis()
-            .try_into()
-            .expect("timestamp value out of u64 range")
-    }
-}
-
-pub trait FromMilis {
-    /// Create protobuf timestamp from miliseconds since epoch
-    ///
-    /// Note there is a resolution difference, as timestamp uses nanoseconds
-    ///
-    /// # Arguments
-    ///
-    /// * millis - time since epoch, in miliseconds; must fit `i64` type
-    fn from_milis(millis: u64) -> Self;
-}
-
-impl FromMilis for Timestamp {
-    /// Create protobuf timestamp from miliseconds since epoch
-    ///
-    /// Note there is a resolution difference, as timestamp uses nanoseconds
-    ///
-    /// # Panics
-    ///  
-    /// Panics when `millis` don't fit `i64` type
-    fn from_milis(millis: u64) -> Self {
-        let dt = chrono::DateTime::from_timestamp_millis(
-            millis
-                .try_into()
-                .expect("milliseconds timestamp out of i64 range"),
-        )
-        .expect("cannot parse timestamp")
-        .to_utc();
-
-        Self {
-            nanos: dt.timestamp_subsec_nanos() as i32,
-            seconds: dt.timestamp(),
-        }
-    }
-}
+// Code moved to crate::time, but kept here for compatibility
+#[deprecated = "use crate::prelude::FromMillis instead"]
+pub use crate::time::FromMillis as FromMilis;
+#[deprecated = "use crate::prelude::ToMillis instead"]
+pub use crate::time::ToMillis as ToMilis;
 
 /// Deserialize string into Timestamp
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Timestamp, D::Error>

--- a/proto/src/time.rs
+++ b/proto/src/time.rs
@@ -1,0 +1,77 @@
+//! Time conversion traits and functions
+
+use crate::google::protobuf::Timestamp;
+pub trait ToMillis {
+    /// Convert protobuf timestamp into miliseconds since epoch
+
+    /// Note there is a resolution difference, as timestamp uses nanoseconds
+    ///
+    /// # Arguments
+    ///
+    /// * millis - time since epoch, in miliseconds
+    ///
+    /// # Panics
+    ///  
+    /// Panics when timestamp doesn't fit `u64` type
+    fn to_millis(&self) -> u64;
+
+    #[deprecated = "use `to_millis` instead"]
+    fn to_milis(&self) -> u64 {
+        self.to_millis()
+    }
+}
+
+impl ToMillis for Timestamp {
+    /// Convert protobuf timestamp into miliseconds since epoch
+    fn to_millis(&self) -> u64 {
+        chrono::DateTime::from_timestamp(self.seconds, self.nanos as u32)
+            .unwrap()
+            .to_utc()
+            .timestamp_millis()
+            .try_into()
+            .expect("timestamp value out of u64 range")
+    }
+}
+
+pub trait FromMillis {
+    /// Create protobuf timestamp from miliseconds since epoch
+    ///
+    /// Note there is a resolution difference, as timestamp uses nanoseconds
+    ///
+    /// # Arguments
+    ///
+    /// * millis - time since epoch, in miliseconds; must fit `i64` type
+    fn from_millis(millis: u64) -> Self;
+
+    #[deprecated = "use `from_millis` instead"]
+    fn from_milis(millis: u64) -> Self
+    where
+        Self: Sized,
+    {
+        Self::from_millis(millis)
+    }
+}
+
+impl FromMillis for Timestamp {
+    /// Create protobuf timestamp from miliseconds since epoch
+    ///
+    /// Note there is a resolution difference, as timestamp uses nanoseconds
+    ///
+    /// # Panics
+    ///  
+    /// Panics when `millis` don't fit `i64` type
+    fn from_millis(millis: u64) -> Self {
+        let dt = chrono::DateTime::from_timestamp_millis(
+            millis
+                .try_into()
+                .expect("milliseconds timestamp out of i64 range"),
+        )
+        .expect("cannot parse timestamp")
+        .to_utc();
+
+        Self {
+            nanos: dt.timestamp_subsec_nanos() as i32,
+            seconds: dt.timestamp(),
+        }
+    }
+}

--- a/proto/src/time.rs
+++ b/proto/src/time.rs
@@ -15,7 +15,7 @@ pub trait ToMillis {
     /// Panics when timestamp doesn't fit `u64` type
     fn to_millis(&self) -> Result<u64, Error>;
 
-    #[deprecated = "use `to_millis` instead"]
+    #[deprecated(note = "use `to_millis` instead", since = "1.3.1")]
     fn to_milis(&self) -> u64 {
         self.to_millis()
             .expect("cannot convert time to milliseconds")
@@ -44,8 +44,7 @@ pub trait FromMillis: Sized {
     ///
     /// * millis - time since epoch, in milliseconds; must fit `i64` type
     fn from_millis(millis: u64) -> Result<Self, Error>;
-
-    #[deprecated = "use `from_millis` instead"]
+    #[deprecated(note = "use `from_millis` instead", since = "1.3.1")]
     fn from_milis(millis: u64) -> Self
     where
         Self: Sized,

--- a/proto/src/time.rs
+++ b/proto/src/time.rs
@@ -2,13 +2,13 @@
 
 use crate::google::protobuf::Timestamp;
 pub trait ToMillis {
-    /// Convert protobuf timestamp into miliseconds since epoch
+    /// Convert protobuf timestamp into milliseconds since epoch
 
     /// Note there is a resolution difference, as timestamp uses nanoseconds
     ///
     /// # Arguments
     ///
-    /// * millis - time since epoch, in miliseconds
+    /// * millis - time since epoch, in milliseconds
     ///
     /// # Panics
     ///  
@@ -22,7 +22,7 @@ pub trait ToMillis {
 }
 
 impl ToMillis for Timestamp {
-    /// Convert protobuf timestamp into miliseconds since epoch
+    /// Convert protobuf timestamp into milliseconds since epoch
     fn to_millis(&self) -> u64 {
         chrono::DateTime::from_timestamp(self.seconds, self.nanos as u32)
             .unwrap()
@@ -34,13 +34,13 @@ impl ToMillis for Timestamp {
 }
 
 pub trait FromMillis {
-    /// Create protobuf timestamp from miliseconds since epoch
+    /// Create protobuf timestamp from milliseconds since epoch
     ///
     /// Note there is a resolution difference, as timestamp uses nanoseconds
     ///
     /// # Arguments
     ///
-    /// * millis - time since epoch, in miliseconds; must fit `i64` type
+    /// * millis - time since epoch, in milliseconds; must fit `i64` type
     fn from_millis(millis: u64) -> Self;
 
     #[deprecated = "use `from_millis` instead"]
@@ -53,7 +53,7 @@ pub trait FromMillis {
 }
 
 impl FromMillis for Timestamp {
-    /// Create protobuf timestamp from miliseconds since epoch
+    /// Create protobuf timestamp from milliseconds since epoch
     ///
     /// Note there is a resolution difference, as timestamp uses nanoseconds
     ///

--- a/proto/tests/unit.rs
+++ b/proto/tests/unit.rs
@@ -3,7 +3,7 @@ use core::convert::TryFrom;
 
 use tenderdash_proto::{
     abci::ResponseException,
-    types::{BlockId as RawBlockId, ConsensusParams, PartSetHeader as RawPartSetHeader},
+    types::{BlockId as RawBlockId, PartSetHeader as RawPartSetHeader},
     Protobuf,
 };
 
@@ -136,6 +136,7 @@ pub fn test_response_exception_from() {
 }
 
 #[test]
+#[cfg(feature = "serde")]
 pub fn test_consensus_params_serde() {
     let json = r#"
     {
@@ -173,5 +174,5 @@ pub fn test_consensus_params_serde() {
     }
     "#;
 
-    let _new_params: ConsensusParams = serde_json::from_str(json).unwrap();
+    let _new_params: tenderdash_proto::types::ConsensusParams = serde_json::from_str(json).unwrap();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

To export requests and responses for debugging purposes, we need all types to implement `serde` serialization and deserialization.

## What was done?

Updated proto and proto-compiler to derive serde on all messages.
Defined new feature, `serde`, that guards serde features.

## How Has This Been Tested?

Run tests

## Breaking Changes

1. New `serde` feature introduced to `tenderdash-proto` (disabled by default).
2. FromMilis and ToMilis traits renamed to FromMillis and ToMillis, return Result<> and are moved to tenderdash_proto::prelude; previous traits still reachable but deprecated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `serde` feature for enhanced serialization support.
	- Added new modules for better organization, including `serializers` and `time`.
	- Implemented new traits for converting Protobuf timestamps to milliseconds.
	- Enhanced logging serialization with a new macro for improved clarity.

- **Bug Fixes**
	- Improved serialization and deserialization processes for `Timestamp` and `Duration` structs.
	- Added error handling for time conversion methods.

- **Tests**
	- Added a new test for verifying the deserialization of `ConsensusParams`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->