### PR TITLE
feat: support ConsensusParams.VersionParams.consensus_version from Tenderdash 1.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: docker logs tenderdash > tenderdash.log 2>&1
 
       - name: Archive docker logs
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: tenderdash.log

--- a/proto-compiler/src/constants.rs
+++ b/proto-compiler/src/constants.rs
@@ -256,4 +256,8 @@ pub static CUSTOM_FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         ".tendermint.types.VersionParams.app_version",
         QUOTED_WITH_DEFAULT,
     ),
+    (
+        ".tendermint.types.VersionParams.consensus_version",
+        QUOTED_WITH_DEFAULT,
+    ),
 ];

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -4,7 +4,7 @@ use tenderdash_proto_compiler::GenerationMode;
 
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
-    const DEFAULT_VERSION: &str = "v1.1.0";
+    const DEFAULT_VERSION: &str = "68a03d69dcfaa64a6edb829b6efed40e72e8e7bd";
 
     // check if TENDERDASH_COMMITISH is already set; if not, set it to the current
     // version

--- a/proto/tests/unit.rs
+++ b/proto/tests/unit.rs
@@ -154,6 +154,7 @@ pub fn test_consensus_params_serde() {
           ]
         },
         "version": {
+          "consensus_version": "1",
           "app_version": "1"
         },
         "synchrony": {
@@ -173,5 +174,6 @@ pub fn test_consensus_params_serde() {
     }
     "#;
 
-    let _new_params: ConsensusParams = serde_json::from_str(json).unwrap();
+    let new_params: ConsensusParams = serde_json::from_str(json).unwrap();
+    assert_eq!(new_params.version.unwrap().consensus_version, 1)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Tenderdash 1.3 includes new .tendermint.types.VersionParams.consensus_version field, and ABCI version 1.2.0.


## What was done?

* Bumped Tenderdash to 1.3.
* Added new field `consensus_version` as quoted.
* Improved release script and docs.

## How Has This Been Tested?

Integrated into Dash Platform.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
