### PR TITLE
doc: clarify protoc requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The repository contains the following crates:
 * [tenderdash-abci](./abci/) - main crate, including ABCI++ socket and tcp server implementation, `Application` trait and re-exporting `tenderdash-proto` crate
 * [tenderdash-proto](./proto/) - ABCI++ messages and data types definitions, and gRPC client/server implementation, generated based on Tenderdash protobuf specifications
 * [tenderdash-proto-compiler](./proto-compiler/) - an internal tool that fetches tenderdash repository and converts protobuf files to Rust
-*
 
 ## Version Compatibility
 
@@ -31,6 +30,8 @@ This library also includes built-in support for ABCI protocol version verificati
 ## Quick start
 
 1. Install dependencies. You can find a current list of dependencies in the [Dockerfile](Dockerfile-debian).
+   * Ensure to install `protoc` from <https://github.com/protocolbuffers/protobuf/releases> and place it in your `$PATH`, as we
+   **don't support protoc shipped with your distribution** (like Ubuntu).
 2. Add tenderdash-abci crate to your project:
 
     ```bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

`protoc` must be installed from the github releases page. People try to use protoc from Ubuntu, and fail. Refs #108 #109 

## What was done?

Clarified docs


## How Has This Been Tested?

N/A

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Quick start" section in the README to clarify the installation of `protoc` from official releases and its inclusion in the user's `$PATH`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->