### PR TITLE
ci: test on stable rust, not nightly

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - "build/docs-website" # TODO remove after it's merged
+
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
@@ -16,9 +16,6 @@ jobs:
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
   gh-pages:
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/deps
         with:
-          toolchain: nightly
+          toolchain: stable
 
       - name: Test tenderdash-proto
         shell: bash
         timeout-minutes: 6
-        run: cargo test --all-features -p tenderdash-proto -- -Zunstable-options --ensure-time
+        run: cargo test --all-features -p tenderdash-proto
 
       - name: Test tenderdash-abci
         shell: bash
@@ -45,7 +45,7 @@ jobs:
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "%p-%m.profraw"
-        run: cargo test --all-features -p tenderdash-abci -- -Zunstable-options --ensure-time
+        run: cargo test --all-features -p tenderdash-abci
 
       - name: Emit docker logs on error
         if: failure()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Github Actions run tests on rust nightly, which fails.
See https://github.com/dashpay/rs-tenderdash-abci/actions/runs/12050788549 

## What was done?

Switched to stable


## How Has This Been Tested?

Pass GH Actions

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated testing workflow to use stable toolchain and simplified test commands.
	- Streamlined GitHub Pages workflow by removing unnecessary comments and clarifying job structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->