### PR TITLE
build(deps): enforce tonic >= 0.12.3 and update other dependencies

### DIFF
--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -20,7 +20,7 @@ regex = { "version" = "1.10" }
 ureq = { "version" = "2.10" }
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 fs_extra = { version = "1.3.0" }
-tonic-build = { version = "0.12", optional = true }
+tonic-build = { version = "0.12.3", optional = true }
 
 
 [features]

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -53,7 +53,7 @@ bytes = { version = "1.7", default-features = false }
 prost = { version = "0.13", default-features = false, features = [
     "prost-derive",
 ] }
-tonic = { version = "0.12", optional = true }
+tonic = { version = "0.12.3", optional = true }
 serde = { version = "1.0.208", default-features = false, features = [
     "derive",
 ], optional = true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

RUSTSEC-2024-0376: Remotely exploitable Denial of Service in Tonic
[#2199](https://github.com/dashpay/platform/issues/2199)


## What was done?

Enforced Tonic 0.12.3 as minimal version.

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `tonic-build` dependency to version `0.12.3` for improved stability.
	- Updated the `tonic` dependency to version `0.12.3` for enhanced performance and potential bug fixes.
- **Tests**
	- Enhanced the clarity of the `test_kvstore` function by capturing the client retrieval result in a variable for better debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->