### PR TITLE
fix(abci): invalid error returned when codec terminates

### DIFF
--- a/abci/tests/kvstore.rs
+++ b/abci/tests/kvstore.rs
@@ -65,8 +65,10 @@ fn test_kvstore() {
     let socket_uri = bind_address.to_string();
     let _td = common::docker::TenderdashDocker::new("tenderdash", None, &socket_uri);
 
+    let next_client = server.next_client();
+    tracing::debug!(?next_client, "next client");
     assert!(matches!(
-        server.next_client(),
+        next_client,
         Err(tenderdash_abci::Error::Cancelled())
     ));
     drop(server);

--- a/abci/tests/kvstore.rs
+++ b/abci/tests/kvstore.rs
@@ -63,7 +63,7 @@ fn test_kvstore() {
     fs::set_permissions(SOCKET, perms).expect("set perms");
 
     let socket_uri = bind_address.to_string();
-    let _td = common::docker::TenderdashDocker::new("tenderdash", None, &socket_uri);
+    let td = common::docker::TenderdashDocker::new("tenderdash", None, &socket_uri);
 
     let next_client = server.next_client();
     tracing::debug!(?next_client, "next client");
@@ -76,6 +76,8 @@ fn test_kvstore() {
     let kvstore_app = kvstore.into_inner().expect("kvstore lock is poisoned");
     assert_eq!(kvstore_app.persisted_state, state_reference);
     assert_eq!(kvstore_app.last_block_height, 1);
+
+    drop(td);
 }
 
 /// An example storage.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When the `Codec` worker terminates (eg. client disconnected or some error occurred), it returns a generic `Error::Async`, 

Detected by flaky Github Actions pipeline.


## What was done?

Return `Error::Cancelled()` instead of `Error::Async`

## How Has This Been Tested?

GHA pipeline pass

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to enhance message processing between the codec and request/response queues.
  
- **Bug Fixes**
	- Improved error handling in message sending to better reflect cancellation scenarios.

- **Tests**
	- Enhanced clarity in the test code for the KVStore by refining variable usage and improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->