### PR TITLE
build!: bump alpine to 3.21, rust to 1.83

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,9 +10,9 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache cargo bin
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ members = ["abci", "proto-compiler", "proto"]
 
 [workspace.package]
 
-rust-version = "1.80"
+rust-version = "1.83"
 version = "1.3.0+1.3.0"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,6 +1,6 @@
 # This is an example Dockerfile, demonstrating build process of rs-tenderdash-abci
 
-FROM rust:1.80-alpine3.20
+FROM rust:1.83-alpine3.21
 
 RUN apk add --no-cache \
         git \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,7 +1,7 @@
 # This is an example Dockerfile, demonstrating build process of rs-tenderdash-abci
 
 # We use Debian base image, as Alpine has some segmentation fault issue
-FROM rust:1.80.0-bookworm
+FROM rust:1.83-bookworm
 
 SHELL ["/bin/bash", "-exc"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Alpine 3.21 is the most recent version, in use by Platform. We prefer to use the same version to build all projects.

## What was done?

Bump Alpine to 3.21. As no Rust 1.80 image is available for alpine 3.21, bumped Rust to 1.83 (matches Dash Platform).

Fix failing audit github action (updated dependencies).

Alpine change only affects tests.
Rust change affects everyone.

## How Has This Been Tested?

GHA

## Breaking Changes

You need Rust 1.83 to build.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the Rust toolchain to a more recent version.
	- Updated container base images to align with the new runtime, ensuring improved performance, stability, and access to the latest enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->