### PR TITLE
build: enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,17 @@
 
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
       time: "13:37"
-      timezone: "UTC"
+      timezone: "Etc/GMT-0"
     ignore:
       # These are peer deps of Cargo and should not be automatically bumped
       - dependency-name: "tenderdash-abci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 5
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Dependabot is not checking github actions. It caused audit action cache to stop working due to outdated actions/cache version.

## What was done?

Configured dependabot to check github actions.

## How Has This Been Tested?

Not tested. It needs to be in the main branch in order to test.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the automated dependency update system with a new daily schedule for GitHub Actions updates, ensuring improved consistency and reliability.
  - Modified the timezone for Cargo updates to enhance scheduling accuracy.
  - These crucial behind-the-scenes enhancements help keep the system secure and up-to-date, contributing to a significantly smoother experience for our users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->