### PR TITLE
chore: improve error displayed when protoc is missing

### DIFF
--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -367,13 +367,20 @@ pub(crate) fn check_deps() -> Result<(), String> {
 
 /// Check if protoc is installed and has the required version
 fn dep_protoc(expected_version: f32) -> Result<f32, String> {
+    const PROTOC_HINT: &str = "please install most recent protoc from \
+https://github.com/protocolbuffers/protobuf/releases/ (note that the version \
+provided by your package manager may be outdated)";
+
     let protoc = prost_build::protoc_from_env();
 
     // Run `protoc --version` and capture the output
-    let output = Command::new(protoc)
-        .arg("--version")
-        .output()
-        .map_err(|e| format!("failed to run: {}", e))?;
+    let output = match Command::new(protoc).arg("--version").output() {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(format!("protoc not found in PATH; {}", PROTOC_HINT));
+        },
+        Err(e) => return Err(format!("failed to run protoc binary: {}", e)),
+    };
 
     // Convert the output to a string
     let out = output.stdout;
@@ -390,8 +397,8 @@ fn dep_protoc(expected_version: f32) -> Result<f32, String> {
 
     if version < expected_version {
         Err(format!(
-            "protoc version must be {} or higher, but found {}; please upgrade: https://github.com/protocolbuffers/protobuf/releases/",
-            expected_version, version
+            "protoc version must be {} or higher, but found {}; {}",
+            expected_version, version, PROTOC_HINT
         ))
     } else {
         Ok(version)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Users who don't have `protoc` installed complain about hard to understand error message:

```
error: failed to run custom build command for tenderdash-proto v1.4.0 (https://github.com/dashpay/rs-tenderdash-abci?tag=v1.4.0#e2dd15f3)

Caused by:
  process didn't exit successfully: /Users/designer/PROJECTS/DASH/dash-evo-tool/target/debug/build/tenderdash-proto-b798b163ac046c68/build-script-build (exit status: 1)
  --- stderr
  [error] => failed to run: No such file or directory (os error 2)
warning: build failed, waiting for other jobs to finish...
```

## What was done?

Improved error handling so that the message is now:

```
error: failed to run custom build command for `tenderdash-proto v1.5.0-dev.1 (/home/lklimek/git/dashevo/rs-tenderdash-abci/proto)`

Caused by:
  process didn't exit successfully: `/data/lklimek/rust/target/debug/build/tenderdash-proto-f95ec29c4d47c339/build-script-build` (exit status: 1)
  --- stderr
  [error] => protoc not found in PATH; please install most recent protoc from https://github.com/protocolbuffers/protobuf/releases/ (note that the version provided by your package manager may be outdated)
warning: build failed, waiting for other jobs to finish...
```


## How Has This Been Tested?

`cargo clean && cargo build`

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when the required `protoc` tool is missing or outdated, providing clearer guidance and installation hints for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->