### PR TITLE
chore: tonic upgrade to 0.14

### DIFF
--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -13,17 +13,17 @@ version.workspace = true
 
 [dependencies]
 walkdir = { version = "2.5.0" }
-prost-build = { version = "0.13" }
+prost-build = { version = "0.14" }
 tempfile = { version = "3.12" }
 regex = { "version" = "1.10" }
 # Use of native-tls-vendored should build vendored openssl, which is required for Alpine build
 ureq = { "version" = "3.0" }
 zip = { version = "4.0", default-features = false, features = ["deflate"] }
 fs_extra = { version = "1.3.0" }
-tonic-build = { version = "0.13.0", optional = true }
+tonic-prost-build = { version = "0.14.2", optional = true }
 
 
 [features]
 default = []
 # Enable gRPC support; needed by server and client features.
-grpc = ["dep:tonic-build"]
+grpc = ["dep:tonic-prost-build"]

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -126,24 +126,24 @@ pub fn proto_compile(mode: GenerationMode) {
     match mode {
         GenerationMode::GrpcServer => {
             #[cfg(feature = "grpc")]
-            tonic_build::configure()
+            tonic_prost_build::configure()
                 .build_client(true)
                 .build_server(true)
                 .build_transport(true)
                 .generate_default_stubs(true)
-                .compile_protos_with_config(pb, &protos, &proto_includes_paths)
+                .compile_with_config(pb, &protos, &proto_includes_paths)
                 .unwrap();
             #[cfg(not(feature = "grpc"))]
             panic!("grpc feature is required to compile {}", mode);
         },
         GenerationMode::GrpcClient => {
             #[cfg(feature = "grpc")]
-            tonic_build::configure()
+            tonic_prost_build::configure()
                 .build_client(true)
                 .build_server(false)
                 .build_transport(false)
                 .generate_default_stubs(true)
-                .compile_protos_with_config(pb, &protos, &proto_includes_paths)
+                .compile_with_config(pb, &protos, &proto_includes_paths)
                 .unwrap();
             #[cfg(not(feature = "grpc"))]
             panic!("grpc feature is required to compile {}", mode);

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -48,7 +48,7 @@ client = [
     "prost/std",
     "dep:tonic",
     "tonic/codegen",
-    "tonic/prost",
+    "dep:tonic-prost",
     "std",
 ]
 
@@ -56,10 +56,11 @@ serde = ["dep:serde", "bytes/serde"]
 
 [dependencies]
 bytes = { version = "1.7", default-features = false }
-prost = { version = "0.13", default-features = false, features = [
-    "prost-derive",
+prost = { version = "0.14", default-features = false, features = [
+    "derive",
 ] }
-tonic = { version = "0.13.0", optional = true, default-features = false }
+tonic = { version = "0.14.2", optional = true, default-features = false }
+tonic-prost = { version = "0.14.2", optional = true }
 serde = { version = "1.0.208", default-features = false, features = [
     "derive",
 ], optional = true }

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -21,7 +21,7 @@ use std::fmt;
 /// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
 /// restricting to that range, we ensure that we can convert to and from [RFC
 /// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -50,7 +50,7 @@ pub struct Timestamp {
 /// or "month". It is related to Timestamp in that the difference between
 /// two Timestamp values is a Duration and it can be added or subtracted
 /// from a Timestamp. Range is approximately +-10,000 years.
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Protobuf Timestamp and Duration types now support equality and hashing, enabling use in sets/maps and easier deduplication and comparisons.
- Chores
  - Upgraded protobuf/gRPC dependencies to the latest 0.14 series for improved compatibility and future-proofing.
  - Updated build tooling to align with newer code generation libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->