### PR TITLE
refactor(proto): replace flex_error with thiserror

### DIFF
--- a/abci/src/merkle.rs
+++ b/abci/src/merkle.rs
@@ -33,7 +33,7 @@ fn inner(left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
 }
 
 fn empty_hash() -> [u8; 32] {
-    return lhash::sha256(&[]);
+    lhash::sha256(&[])
 }
 
 fn get_split_point(length: i64) -> i64 {

--- a/abci/src/server/codec.rs
+++ b/abci/src/server/codec.rs
@@ -37,7 +37,7 @@ pub struct Codec {
     response_tx: Sender<Response>,
 }
 
-impl<'a> Codec {
+impl Codec {
     pub(crate) fn new<L>(
         listener: Arc<Mutex<L>>,
         cancel: CancellationToken,

--- a/abci/tests/kvstore.rs
+++ b/abci/tests/kvstore.rs
@@ -170,7 +170,7 @@ impl<'a> KVStoreABCI<'a> {
         KVStoreABCI { kvstore }
     }
 
-    fn lock_kvstore(&self) -> RwLockWriteGuard<KVStore> {
+    fn lock_kvstore(&'a self) -> RwLockWriteGuard<'a, KVStore> {
         self.kvstore.write().expect("kvstore lock is poisoned")
     }
 }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -75,7 +75,7 @@ time = { version = "0.3.36", default-features = false, features = [
     "macros",
     "parsing",
 ] }
-flex-error = { version = "0.4.4", default-features = false }
+thiserror = { version = "2.0.3" }
 chrono = { version = "0.4.38", default-features = false }
 derive_more = { version = "2.0", features = ["from", "from_str"] }
 

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -5,40 +5,52 @@ use core::{convert::TryFrom, fmt::Display, num::TryFromIntError};
 #[cfg(feature = "std")]
 use std::{fmt::Display, num::TryFromIntError};
 
-use flex_error::{DisplayOnly, define_error};
 use prost::{DecodeError, EncodeError};
+use thiserror::Error as ThisError;
 
 use crate::prelude::*;
 
-define_error! {
-    Error {
-        TimeConversion
-            { reason: String }
-            | e | {
-            format!("error converting time: {}", e.reason)
-        },
-        TryFromProtobuf
-            { reason: String }
-            | e | {
-                format!("error converting message type into domain type: {}",
-                    e.reason)
-            },
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("error converting time: {reason}")]
+    TimeConversion { reason: String },
 
-        EncodeMessage
-            [ DisplayOnly<EncodeError> ]
-            | _ | { "error encoding message into buffer" },
+    #[error("error converting message type into domain type: {reason}")]
+    TryFromProtobuf { reason: String },
 
-        DecodeMessage
-            [ DisplayOnly<DecodeError> ]
-            | _ | { "error decoding buffer into message" },
+    // Keep messages consistent with previous flex_error display strings
+    #[error("error encoding message into buffer")]
+    EncodeMessage(EncodeError),
 
-        ParseLength
-            [ DisplayOnly<TryFromIntError> ]
-            | _ | { "error parsing encoded length" },
-    }
+    #[error("error decoding buffer into message")]
+    DecodeMessage(DecodeError),
+
+    #[error("error parsing encoded length")]
+    ParseLength(TryFromIntError),
 }
 
 impl Error {
+    // Backwards-compatible constructors mirroring flex_error-generated fns
+    pub fn time_conversion(reason: String) -> Self {
+        Self::TimeConversion { reason }
+    }
+
+    pub fn try_from_protobuf(reason: String) -> Self {
+        Self::TryFromProtobuf { reason }
+    }
+
+    pub fn encode_message(err: EncodeError) -> Self {
+        Self::EncodeMessage(err)
+    }
+
+    pub fn decode_message(err: DecodeError) -> Self {
+        Self::DecodeMessage(err)
+    }
+
+    pub fn parse_length(err: TryFromIntError) -> Self {
+        Self::ParseLength(err)
+    }
+
     pub fn try_from<Raw, T, E>(e: E) -> Error
     where
         E: Display,


### PR DESCRIPTION
## Issue being fixed or feature implemented

`flex_error` requires deprecated dtolnay/paste project, causing `audit` alerts.

## What was done?

Replaced flex_error with thiserror


## How Has This Been Tested?

GHA

## Breaking Changes

Error handling might be affected, but it should be backwards-compatible.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Streamlined error handling with clearer, user-friendly messages and explicit error types. No functional changes.
* Chores
  * Replaced error-handling dependency with a standard, lightweight alternative for consistency.
* Tests
  * Improved lifetime handling in test helpers for safer concurrency; no impact on behavior.
* Style
  * Minor code cleanup and simplifications with no change to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->