### PR TITLE
build: bump version to 1.5.0-dev.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ members = ["abci", "proto-compiler", "proto"]
 [workspace.package]
 
 rust-version = "1.85"
-version = "1.5.0-dev.1"
+version = "1.5.0-dev.2"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -4,7 +4,7 @@ use tenderdash_proto_compiler::GenerationMode;
 
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
-    const DEFAULT_VERSION: &str = "v1.5.0-dev.1";
+    const DEFAULT_VERSION: &str = "v1.5.0-dev.3";
 
     // check if TENDERDASH_COMMITISH is already set; if not, set it to the current
     // version


### PR DESCRIPTION
Release v1.5.0-dev.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped workspace version to 1.5.0-dev.2.
  * Updated the default fallback version used during builds when no environment override is provided (now v1.5.0-dev.3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->