### PR TITLE
build(deps): bump tracing-subscriber, ureq and zip dependencies, force bincode 2.0.0-rc.3

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -59,7 +59,7 @@ uuid = { version = "1.8.0", features = ["v4", "fast-rng"], optional = true }
 tenderdash-proto = { path = "../proto", default-features = false }
 bytes = { version = "1.6.0" }
 tracing = { version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.18", optional = true, default-features = false, features = [
+tracing-subscriber = { version = "0.3.22", optional = true, default-features = false, features = [
     "ansi",
     "env-filter",
 ] }
@@ -84,7 +84,9 @@ futures = { version = "0.3.30", optional = true }
 
 [dev-dependencies]
 anyhow = { version = "1.0.82" }
-bincode = { version = "2.0.0-rc.3" }
+# Dash Platform requires specific version of bincode
+bincode = { version = "=2.0.0-rc.3" }
+bincode_derive = { version = "=2.0.0-rc.3" }
 blake2 = { version = "0.10.6" }
 bollard = { version = "0.19" }
 futures = { version = "0.3.30" }

--- a/proto-compiler/Cargo.toml
+++ b/proto-compiler/Cargo.toml
@@ -17,8 +17,8 @@ prost-build = { version = "0.14" }
 tempfile = { version = "3.12" }
 regex = { "version" = "1.10" }
 # Use of native-tls-vendored should build vendored openssl, which is required for Alpine build
-ureq = { "version" = "3.0" }
-zip = { version = "5.0", default-features = false, features = ["deflate"] }
+ureq = { "version" = "3.1.4" }
+zip = { version = "7.0", default-features = false, features = ["deflate"] }
 fs_extra = { version = "1.3.0" }
 tonic-prost-build = { version = "0.14.2", optional = true }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

`cargo audit` shows a few dependencies 

## What was done?

Updated tracing-subscriber, ureq and zip.

Enforced bincode 2.0.0-rc.3 (dev depenedency used in tests) which is version required by dash platform.

## How Has This Been Tested?

cargo test and GHA green

## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and build dependencies to newer versions for improved stability and long-term compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->