### PR TITLE
fix(proto): build tries to write outside Codex sandbox

### DIFF
--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -104,12 +104,8 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
 
 /// Download file from URL
 fn download(url: &str, archive_file: &Path) -> Result<(), String> {
-    let mut file = File::create(archive_file).map_err(|e| {
-        format!(
-            "cannot create archive file {}: {e}",
-            archive_file.display()
-        )
-    })?;
+    let mut file = File::create(archive_file)
+        .map_err(|e| format!("cannot create archive file {}: {e}", archive_file.display()))?;
     let rb = ureq::get(url)
         .call()
         .map_err(|e| format!("cannot download archive from: {}: {:?}", url, e))?;
@@ -149,10 +145,8 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
 
 /// Find a subdirectory of a parent path which has provided name prefix
 fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
-    let dir_content = fs_extra::dir::get_dir_content(parent).expect(&format!(
-        "cannot list tmp dir {}",
-        parent.display()
-    ));
+    let dir_content = fs_extra::dir::get_dir_content(parent)
+        .expect(&format!("cannot list tmp dir {}", parent.display()));
     let mut src_dir = String::new();
     for directory in dir_content.directories {
         let directory = Path::new(&directory)

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    fs::{File, copy, create_dir_all, read_to_string, remove_dir_all},
+    fs::{File, read_to_string},
     io::Write,
     path::{Path, PathBuf},
     process::Command,
@@ -152,38 +152,6 @@ fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
     parent.join(src_dir)
 }
 
-/// Copy generated files to target folder
-pub fn copy_files(src_dir: &Path, target_dir: &Path) {
-    // Remove old compiled files
-    remove_dir_all(target_dir).unwrap_or_default();
-    create_dir_all(target_dir).unwrap();
-
-    // Copy new compiled files (prost does not use folder structures)
-    let errors = WalkDir::new(src_dir)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_file())
-        .map(|e| {
-            copy(
-                e.path(),
-                std::path::Path::new(&format!(
-                    "{}/{}",
-                    &target_dir.display(),
-                    &e.file_name().to_os_string().to_str().unwrap()
-                )),
-            )
-        })
-        .filter_map(|e| e.err())
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for e in errors {
-            println!("[error] => Error while copying compiled file: {e}");
-        }
-        panic!("[error] => Aborted.");
-    }
-}
-
 /// Walk through the list of directories and gather all *.proto files
 pub fn find_proto_files(proto_paths: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut protos: Vec<PathBuf> = vec![];
@@ -263,7 +231,7 @@ pub fn generate_tenderdash_lib(
     file_names.sort();
 
     let mut content =
-        String::from("//! Tenderdash-proto auto-generated sub-modules for Tenderdash\n");
+        String::from("/// Tenderdash-proto auto-generated sub-modules for Tenderdash\n");
     let tab = "    ".to_string();
 
     for file_name in file_names {

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -230,8 +230,7 @@ pub fn generate_tenderdash_lib(
         .collect::<Vec<_>>();
     file_names.sort();
 
-    let mut content =
-        String::from("/// Tenderdash-proto auto-generated sub-modules for Tenderdash\n");
+    let mut content = String::new();
     let tab = "    ".to_string();
 
     for file_name in file_names {
@@ -280,7 +279,9 @@ pub mod meta {{
         abci_ver,
         td_ver,
         mode,
-    );
+    )
+    .trim_start()
+    .into();
 
     let mut file =
         File::create(tenderdash_lib_target).expect("tenderdash library file create failed");

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -27,7 +27,10 @@ pub fn fetch_commitish(tenderdash_dir: &Path, cache_dir: &Path, url: &str, commi
 
     // ensure cache dir exists
     if !cache_dir.is_dir() {
-        std::fs::create_dir_all(cache_dir).expect("cannot create cache directory");
+        std::fs::create_dir_all(cache_dir).expect(&format!(
+            "cannot create cache directory {}",
+            cache_dir.display()
+        ));
     }
 
     let archive_file = cache_dir.join(format!("tenderdash-{}.zip", commitish));
@@ -42,9 +45,14 @@ pub fn fetch_commitish(tenderdash_dir: &Path, cache_dir: &Path, url: &str, commi
 
     let options = fs_extra::dir::CopyOptions::new().content_only(true);
 
-    fs_extra::dir::create(tenderdash_dir, true).expect("cannot create destination directory");
-    fs_extra::dir::move_dir(src_dir, tenderdash_dir, &options)
-        .expect("cannot move tenderdash directory");
+    fs_extra::dir::create(tenderdash_dir, true).expect(&format!(
+        "cannot create destination directory {}",
+        tenderdash_dir.display()
+    ));
+    fs_extra::dir::move_dir(src_dir, tenderdash_dir, &options).expect(&format!(
+        "cannot move tenderdash directory to {}",
+        tenderdash_dir.display()
+    ));
 }
 
 /// Download file from URL and unzip it to `dest_dir`
@@ -96,8 +104,12 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
 
 /// Download file from URL
 fn download(url: &str, archive_file: &Path) -> Result<(), String> {
-    let mut file =
-        File::create(archive_file).map_err(|e| format!("cannot create file: {:?}", e))?;
+    let mut file = File::create(archive_file).map_err(|e| {
+        format!(
+            "cannot create archive file {}: {e}",
+            archive_file.display()
+        )
+    })?;
     let rb = ureq::get(url)
         .call()
         .map_err(|e| format!("cannot download archive from: {}: {:?}", url, e))?;
@@ -121,20 +133,26 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
         // no archive file, so we request another download
         return Err("archive file does not exist".to_string());
     }
-    let file = File::open(archive_file).expect("cannot open downloaded zip");
+    let file = File::open(archive_file).expect(&format!(
+        "cannot open downloaded zip {}",
+        archive_file.display()
+    ));
     let mut archive =
         zip::ZipArchive::new(&file).map_err(|e| format!("cannot open zip archive: {:?}", e))?;
 
     archive
         .extract(dest_dir)
-        .map_err(|e| format!("cannot extract archive: {:?}", e))?;
+        .map_err(|e| format!("cannot extract archive to {}: {e}", dest_dir.display()))?;
 
     Ok(())
 }
 
 /// Find a subdirectory of a parent path which has provided name prefix
 fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
-    let dir_content = fs_extra::dir::get_dir_content(parent).expect("cannot ls tmp dir");
+    let dir_content = fs_extra::dir::get_dir_content(parent).expect(&format!(
+        "cannot list tmp dir {}",
+        parent.display()
+    ));
     let mut src_dir = String::new();
     for directory in dir_content.directories {
         let directory = Path::new(&directory)
@@ -176,7 +194,8 @@ pub fn abci_version<T: AsRef<Path>>(dir: T) -> String {
     let mut file_path = dir.as_ref().to_path_buf();
     file_path.push("version/version.go");
 
-    let contents = read_to_string(&file_path).expect("cannot read version/version.go");
+    let contents =
+        read_to_string(&file_path).expect(&format!("cannot read {}", file_path.display()));
     use regex::Regex;
 
     let re = Regex::new(r##"(?m)^\s+ABCISemVer\s*=\s*"([^"]+)"\s+*$"##).unwrap();
@@ -195,7 +214,8 @@ pub fn tenderdash_version<T: AsRef<Path>>(dir: T) -> String {
     let mut file_path = dir.as_ref().to_path_buf();
     file_path.push("version/version.go");
 
-    let contents = read_to_string(&file_path).expect("cannot read version/version.go");
+    let contents =
+        read_to_string(&file_path).expect(&format!("cannot read {}", file_path.display()));
     use regex::Regex;
 
     let re = Regex::new(r##"(?m)^\s+TMVersionDefault\s*=\s*"([^"]+)"\s+*$"##).unwrap();
@@ -283,8 +303,10 @@ pub mod meta {{
     .trim_start()
     .into();
 
-    let mut file =
-        File::create(tenderdash_lib_target).expect("tenderdash library file create failed");
+    let mut file = File::create(tenderdash_lib_target).expect(&format!(
+        "tenderdash library file create failed {}",
+        tenderdash_lib_target.display()
+    ));
     file.write_all(content.as_bytes())
         .expect("tenderdash library file write failed");
 }
@@ -320,12 +342,19 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
 
     let expected = commitish.to_string();
 
-    match read_to_string(state_file) {
+    match read_to_string(&state_file) {
         Ok(content) => {
             println!("[info] => Detected Tenderdash version: {}.", content);
             content == expected
         },
-        Err(_) => false,
+        Err(e) => {
+            eprintln!(
+                "[warn] => Failed to read download.state file {}: {}",
+                state_file.display(),
+                e
+            );
+            false
+        },
     }
 }
 

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -151,7 +151,7 @@ pub fn proto_compile(mode: GenerationMode) {
     }
 
     println!(
-        "[info] => Generated files copied to {}.",
+        "[info] => Generated files written to {}.",
         prost_out_dir.display()
     );
 
@@ -167,7 +167,7 @@ pub fn proto_compile(mode: GenerationMode) {
     println!("[info] => Done!");
 }
 
-fn resolve_output_base() -> PathBuf {
+pub fn resolve_output_base() -> PathBuf {
     var("TENDERDASH_PROTO_OUT_DIR")
         .map(PathBuf::from)
         .or_else(|_| var("OUT_DIR").map(PathBuf::from))

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -34,10 +34,12 @@ pub fn proto_compile(mode: GenerationMode) {
     let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| output_base.join("tenderdash-cache"));
-    let tenderdash_dir = PathBuf::from(
-        var("TENDERDASH_DIR")
-            .unwrap_or_else(|_| output_base.join("tenderdash").to_str().unwrap().to_string()),
-    );
+    let tenderdash_dir = PathBuf::from(var("TENDERDASH_DIR").unwrap_or_else(|_| {
+        output_base
+            .join("tenderdash")
+            .to_string_lossy()
+            .into_owned()
+    }));
 
     println!(
         "[info] => Tenderdash cache dir: {}",

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -33,17 +33,25 @@ pub fn proto_compile(mode: GenerationMode) {
     std::fs::create_dir_all(&prost_out_dir)
         .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
 
-    let cargo_target_dir = match std::env::var("CARGO_TARGET_DIR") {
-        Ok(s) => PathBuf::from(s),
-        Err(_) => root.join("..").join("target"),
-    };
+    let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| output_base.join("tenderdash-cache"));
     let tenderdash_dir = PathBuf::from(var("TENDERDASH_DIR").unwrap_or_else(|_| {
-        cargo_target_dir
+        output_base
             .join("tenderdash")
             .to_str()
             .unwrap()
             .to_string()
     }));
+
+    println!(
+        "[info] => Tenderdash cache dir: {}",
+        cargo_target_dir.display()
+    );
+    println!(
+        "[info] => Tenderdash source dir: {}",
+        tenderdash_dir.display()
+    );
 
     let thirdparty_dir = root.join("third_party");
 

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -28,21 +28,16 @@ pub fn proto_compile(mode: GenerationMode) {
     let prost_out_dir = output_base.join(mode.module_name());
     let tenderdash_lib_target = prost_out_dir.join("mod.rs");
 
-    // ensure we start clean
-    std::fs::remove_dir_all(&prost_out_dir).ok();
     std::fs::create_dir_all(&prost_out_dir)
         .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
 
     let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| output_base.join("tenderdash-cache"));
-    let tenderdash_dir = PathBuf::from(var("TENDERDASH_DIR").unwrap_or_else(|_| {
-        output_base
-            .join("tenderdash")
-            .to_str()
-            .unwrap()
-            .to_string()
-    }));
+    let tenderdash_dir = PathBuf::from(
+        var("TENDERDASH_DIR")
+            .unwrap_or_else(|_| output_base.join("tenderdash").to_str().unwrap().to_string()),
+    );
 
     println!(
         "[info] => Tenderdash cache dir: {}",
@@ -68,6 +63,10 @@ pub fn proto_compile(mode: GenerationMode) {
         || !check_state(&prost_out_dir, &commitish);
 
     if download {
+        // ensure we start clean when regenerating
+        std::fs::remove_dir_all(&prost_out_dir).ok();
+        std::fs::create_dir_all(&prost_out_dir)
+            .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
         println!("[info] => Fetching {TENDERDASH_REPO} at {commitish} into {tenderdash_dir:?}.");
         fetch_commitish(
             &PathBuf::from(&tenderdash_dir),
@@ -175,6 +174,7 @@ pub fn proto_compile(mode: GenerationMode) {
     println!("[info] => Done!");
 }
 
+/// Resolve output base directory for generated files.
 pub fn resolve_output_base() -> PathBuf {
     var("TENDERDASH_PROTO_OUT_DIR")
         .map(PathBuf::from)

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -1,11 +1,9 @@
 use std::{env::var, path::PathBuf};
 
-use tempfile::tempdir;
-
 mod functions;
 use functions::{
-    abci_version, copy_files, fetch_commitish, find_proto_files, generate_tenderdash_lib,
-    tenderdash_commitish, tenderdash_version,
+    abci_version, fetch_commitish, find_proto_files, generate_tenderdash_lib, tenderdash_commitish,
+    tenderdash_version,
 };
 
 mod constants;
@@ -26,17 +24,14 @@ use crate::functions::{check_deps, check_state, save_state};
 pub fn proto_compile(mode: GenerationMode) {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let prost_out_dir = root
-        .join("..")
-        .join("proto")
-        .join("src")
-        .join(mode.module_name());
+    let output_base = resolve_output_base();
+    let prost_out_dir = output_base.join(mode.module_name());
     let tenderdash_lib_target = prost_out_dir.join("mod.rs");
 
-    let out_dir = var("OUT_DIR")
-        .map(PathBuf::from)
-        .or_else(|_| tempdir().map(|d| d.into_path()))
-        .unwrap();
+    // ensure we start clean
+    std::fs::remove_dir_all(&prost_out_dir).ok();
+    std::fs::create_dir_all(&prost_out_dir)
+        .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
 
     let cargo_target_dir = match std::env::var("CARGO_TARGET_DIR") {
         Ok(s) => PathBuf::from(s),
@@ -94,7 +89,7 @@ pub fn proto_compile(mode: GenerationMode) {
     let mut pb = prost_build::Config::new();
 
     // Compile proto files with added annotations, exchange prost_types to our own
-    pb.out_dir(&out_dir);
+    pb.out_dir(&prost_out_dir);
     pb.type_attribute(".", constants::SERIALIZED);
     for type_attribute in CUSTOM_TYPE_ATTRIBUTES {
         println!("[info] => Adding type attribute: {:?}", type_attribute);
@@ -127,6 +122,7 @@ pub fn proto_compile(mode: GenerationMode) {
         GenerationMode::GrpcServer => {
             #[cfg(feature = "grpc")]
             tonic_prost_build::configure()
+                .out_dir(prost_out_dir.clone())
                 .build_client(true)
                 .build_server(true)
                 .build_transport(true)
@@ -139,6 +135,7 @@ pub fn proto_compile(mode: GenerationMode) {
         GenerationMode::GrpcClient => {
             #[cfg(feature = "grpc")]
             tonic_prost_build::configure()
+                .out_dir(prost_out_dir.clone())
                 .build_client(true)
                 .build_server(false)
                 .build_transport(false)
@@ -153,11 +150,13 @@ pub fn proto_compile(mode: GenerationMode) {
         },
     }
 
-    println!("[info] => Removing old structs and copying new structs.");
-    copy_files(&out_dir, &prost_out_dir); // This panics if it fails.
+    println!(
+        "[info] => Generated files copied to {}.",
+        prost_out_dir.display()
+    );
 
     generate_tenderdash_lib(
-        &out_dir,
+        &prost_out_dir,
         &tenderdash_lib_target,
         &abci_ver,
         &tenderdash_ver,
@@ -166,4 +165,15 @@ pub fn proto_compile(mode: GenerationMode) {
 
     save_state(&prost_out_dir, &commitish);
     println!("[info] => Done!");
+}
+
+fn resolve_output_base() -> PathBuf {
+    var("TENDERDASH_PROTO_OUT_DIR")
+        .map(PathBuf::from)
+        .or_else(|_| var("OUT_DIR").map(PathBuf::from))
+        .unwrap_or_else(|_| {
+            panic!(
+                "OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it"
+            )
+        })
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, path::PathBuf};
 
 use tenderdash_proto_compiler::GenerationMode;
 
@@ -19,6 +19,16 @@ fn main() {
     // note it should be safe to build both server and client; we will just not use
     // them in the lib.rs
 
+    let output_base = proto_output_base();
+    println!(
+        "[info] => Using Tenderdash proto output dir: {}",
+        output_base.display()
+    );
+    println!(
+        "cargo:rustc-env=TENDERDASH_PROTO_OUT_DIR={}",
+        output_base.display()
+    );
+
     #[cfg(feature = "server")]
     // build gRPC server (includes client)
     tenderdash_proto_compiler::proto_compile(GenerationMode::GrpcServer);
@@ -32,4 +42,12 @@ fn main() {
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=TENDERDASH_COMMITISH");
+    println!("cargo:rerun-if-env-changed=TENDERDASH_PROTO_OUT_DIR");
+}
+
+fn proto_output_base() -> PathBuf {
+    env::var("TENDERDASH_PROTO_OUT_DIR")
+        .or_else(|_| env::var("OUT_DIR"))
+        .map(PathBuf::from)
+        .expect("OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it")
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,6 @@
-use std::{env, path::PathBuf};
+use std::env;
 
-use tenderdash_proto_compiler::GenerationMode;
+use tenderdash_proto_compiler::{GenerationMode, resolve_output_base};
 
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
@@ -19,7 +19,7 @@ fn main() {
     // note it should be safe to build both server and client; we will just not use
     // them in the lib.rs
 
-    let output_base = proto_output_base();
+    let output_base = resolve_output_base();
     println!(
         "[info] => Using Tenderdash proto output dir: {}",
         output_base.display()
@@ -43,11 +43,4 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=TENDERDASH_COMMITISH");
     println!("cargo:rerun-if-env-changed=TENDERDASH_PROTO_OUT_DIR");
-}
-
-fn proto_output_base() -> PathBuf {
-    env::var("TENDERDASH_PROTO_OUT_DIR")
-        .or_else(|_| env::var("OUT_DIR"))
-        .map(PathBuf::from)
-        .expect("OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it")
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -37,16 +37,22 @@ use prost::{Message, encoding::encoded_len_varint};
 #[cfg(not(any(feature = "server", feature = "client")))]
 #[rustfmt::skip]
 #[allow(clippy::empty_docs)]
-pub mod tenderdash_nostd;
+pub mod tenderdash_nostd {
+    include!(concat!(env!("TENDERDASH_PROTO_OUT_DIR"), "/tenderdash_nostd/mod.rs"));
+}
 
 #[cfg(feature = "server")]
 #[rustfmt::skip]
 #[allow(clippy::empty_docs)]
-pub mod tenderdash_grpc;
+pub mod tenderdash_grpc {
+    include!(concat!(env!("TENDERDASH_PROTO_OUT_DIR"), "/tenderdash_grpc/mod.rs"));
+}
 #[cfg(feature = "client")]
 #[rustfmt::skip]
 #[allow(clippy::empty_docs)]
-pub mod tenderdash_grpc_client;
+pub mod tenderdash_grpc_client {
+    include!(concat!(env!("TENDERDASH_PROTO_OUT_DIR"), "/tenderdash_grpc_client/mod.rs"));
+}
 
 // Now, re-export correct module
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Build of tenderdash-proto run by codex fails because build process tries to write outside the sandbox.

## What was done?

* generate source code to OUT_DIR
* allow overriding location with TENDERDASH_PROTO_OUT_DIR 

## How Has This Been Tested?

Run cargo check several times, run cargo test. Use in platform.

## Breaking Changes

None

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build now discovers and exposes the proto output base at build time so generated artifacts are consumed in place.

* **Refactor**
  * Consolidated generated code into a single resolved output directory and simplified generation flow; removed an intermediate copy step.
  * Replaced a legacy helper with a resolver for the output base (API surface adjusted).

* **Bug Fixes**
  * Improved error and log messages to include relevant file and directory paths for clearer diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->