### PR TITLE
refactor(proto-compiler): error handling minimizing panics

### DIFF
--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -104,12 +104,8 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
 
 /// Download file from URL
 fn download(url: &str, archive_file: &Path) -> Result<(), String> {
-    let mut file = File::create(archive_file).map_err(|e| {
-        format!(
-            "cannot create archive file {}: {e}",
-            archive_file.display()
-        )
-    })?;
+    let mut file = File::create(archive_file)
+        .map_err(|e| format!("cannot create archive file {}: {e}", archive_file.display()))?;
     let rb = ureq::get(url)
         .call()
         .map_err(|e| format!("cannot download archive from: {}: {:?}", url, e))?;
@@ -149,10 +145,8 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
 
 /// Find a subdirectory of a parent path which has provided name prefix
 fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
-    let dir_content = fs_extra::dir::get_dir_content(parent).expect(&format!(
-        "cannot list tmp dir {}",
-        parent.display()
-    ));
+    let dir_content = fs_extra::dir::get_dir_content(parent)
+        .expect(&format!("cannot list tmp dir {}", parent.display()));
     let mut src_dir = String::new();
     for directory in dir_content.directories {
         let directory = Path::new(&directory)

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    fs::{File, copy, create_dir_all, read_to_string, remove_dir_all},
+    fs::{File, read_to_string},
     io::Write,
     path::{Path, PathBuf},
     process::Command,
@@ -152,38 +152,6 @@ fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
     parent.join(src_dir)
 }
 
-/// Copy generated files to target folder
-pub fn copy_files(src_dir: &Path, target_dir: &Path) {
-    // Remove old compiled files
-    remove_dir_all(target_dir).unwrap_or_default();
-    create_dir_all(target_dir).unwrap();
-
-    // Copy new compiled files (prost does not use folder structures)
-    let errors = WalkDir::new(src_dir)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_file())
-        .map(|e| {
-            copy(
-                e.path(),
-                std::path::Path::new(&format!(
-                    "{}/{}",
-                    &target_dir.display(),
-                    &e.file_name().to_os_string().to_str().unwrap()
-                )),
-            )
-        })
-        .filter_map(|e| e.err())
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for e in errors {
-            println!("[error] => Error while copying compiled file: {e}");
-        }
-        panic!("[error] => Aborted.");
-    }
-}
-
 /// Walk through the list of directories and gather all *.proto files
 pub fn find_proto_files(proto_paths: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut protos: Vec<PathBuf> = vec![];
@@ -263,7 +231,7 @@ pub fn generate_tenderdash_lib(
     file_names.sort();
 
     let mut content =
-        String::from("//! Tenderdash-proto auto-generated sub-modules for Tenderdash\n");
+        String::from("/// Tenderdash-proto auto-generated sub-modules for Tenderdash\n");
     let tab = "    ".to_string();
 
     for file_name in file_names {

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -152,7 +152,7 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
         return Err("archive file does not exist".to_string());
     }
     let file = File::open(archive_file)
-        .unwrap_or_else(|e| panic!("cannot open downloaded zip {}: {e}", archive_file.display()));
+        .map_err(|e| format!("cannot open downloaded zip {}: {e}", archive_file.display()))?;
     let mut archive =
         zip::ZipArchive::new(&file).map_err(|e| format!("cannot open zip archive: {:?}", e))?;
 

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -230,8 +230,7 @@ pub fn generate_tenderdash_lib(
         .collect::<Vec<_>>();
     file_names.sort();
 
-    let mut content =
-        String::from("/// Tenderdash-proto auto-generated sub-modules for Tenderdash\n");
+    let mut content = String::new();
     let tab = "    ".to_string();
 
     for file_name in file_names {
@@ -280,7 +279,9 @@ pub mod meta {{
         abci_ver,
         td_ver,
         mode,
-    );
+    )
+    .trim_start()
+    .into();
 
     let mut file =
         File::create(tenderdash_lib_target).expect("tenderdash library file create failed");

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -27,7 +27,10 @@ pub fn fetch_commitish(tenderdash_dir: &Path, cache_dir: &Path, url: &str, commi
 
     // ensure cache dir exists
     if !cache_dir.is_dir() {
-        std::fs::create_dir_all(cache_dir).expect("cannot create cache directory");
+        std::fs::create_dir_all(cache_dir).expect(&format!(
+            "cannot create cache directory {}",
+            cache_dir.display()
+        ));
     }
 
     let archive_file = cache_dir.join(format!("tenderdash-{}.zip", commitish));
@@ -42,9 +45,14 @@ pub fn fetch_commitish(tenderdash_dir: &Path, cache_dir: &Path, url: &str, commi
 
     let options = fs_extra::dir::CopyOptions::new().content_only(true);
 
-    fs_extra::dir::create(tenderdash_dir, true).expect("cannot create destination directory");
-    fs_extra::dir::move_dir(src_dir, tenderdash_dir, &options)
-        .expect("cannot move tenderdash directory");
+    fs_extra::dir::create(tenderdash_dir, true).expect(&format!(
+        "cannot create destination directory {}",
+        tenderdash_dir.display()
+    ));
+    fs_extra::dir::move_dir(src_dir, tenderdash_dir, &options).expect(&format!(
+        "cannot move tenderdash directory to {}",
+        tenderdash_dir.display()
+    ));
 }
 
 /// Download file from URL and unzip it to `dest_dir`
@@ -96,8 +104,12 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
 
 /// Download file from URL
 fn download(url: &str, archive_file: &Path) -> Result<(), String> {
-    let mut file =
-        File::create(archive_file).map_err(|e| format!("cannot create file: {:?}", e))?;
+    let mut file = File::create(archive_file).map_err(|e| {
+        format!(
+            "cannot create archive file {}: {e}",
+            archive_file.display()
+        )
+    })?;
     let rb = ureq::get(url)
         .call()
         .map_err(|e| format!("cannot download archive from: {}: {:?}", url, e))?;
@@ -121,20 +133,26 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
         // no archive file, so we request another download
         return Err("archive file does not exist".to_string());
     }
-    let file = File::open(archive_file).expect("cannot open downloaded zip");
+    let file = File::open(archive_file).expect(&format!(
+        "cannot open downloaded zip {}",
+        archive_file.display()
+    ));
     let mut archive =
         zip::ZipArchive::new(&file).map_err(|e| format!("cannot open zip archive: {:?}", e))?;
 
     archive
         .extract(dest_dir)
-        .map_err(|e| format!("cannot extract archive: {:?}", e))?;
+        .map_err(|e| format!("cannot extract archive to {}: {e}", dest_dir.display()))?;
 
     Ok(())
 }
 
 /// Find a subdirectory of a parent path which has provided name prefix
 fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
-    let dir_content = fs_extra::dir::get_dir_content(parent).expect("cannot ls tmp dir");
+    let dir_content = fs_extra::dir::get_dir_content(parent).expect(&format!(
+        "cannot list tmp dir {}",
+        parent.display()
+    ));
     let mut src_dir = String::new();
     for directory in dir_content.directories {
         let directory = Path::new(&directory)
@@ -176,7 +194,8 @@ pub fn abci_version<T: AsRef<Path>>(dir: T) -> String {
     let mut file_path = dir.as_ref().to_path_buf();
     file_path.push("version/version.go");
 
-    let contents = read_to_string(&file_path).expect("cannot read version/version.go");
+    let contents =
+        read_to_string(&file_path).expect(&format!("cannot read {}", file_path.display()));
     use regex::Regex;
 
     let re = Regex::new(r##"(?m)^\s+ABCISemVer\s*=\s*"([^"]+)"\s+*$"##).unwrap();
@@ -195,7 +214,8 @@ pub fn tenderdash_version<T: AsRef<Path>>(dir: T) -> String {
     let mut file_path = dir.as_ref().to_path_buf();
     file_path.push("version/version.go");
 
-    let contents = read_to_string(&file_path).expect("cannot read version/version.go");
+    let contents =
+        read_to_string(&file_path).expect(&format!("cannot read {}", file_path.display()));
     use regex::Regex;
 
     let re = Regex::new(r##"(?m)^\s+TMVersionDefault\s*=\s*"([^"]+)"\s+*$"##).unwrap();
@@ -283,8 +303,10 @@ pub mod meta {{
     .trim_start()
     .into();
 
-    let mut file =
-        File::create(tenderdash_lib_target).expect("tenderdash library file create failed");
+    let mut file = File::create(tenderdash_lib_target).expect(&format!(
+        "tenderdash library file create failed {}",
+        tenderdash_lib_target.display()
+    ));
     file.write_all(content.as_bytes())
         .expect("tenderdash library file write failed");
 }
@@ -320,12 +342,19 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
 
     let expected = commitish.to_string();
 
-    match read_to_string(state_file) {
+    match read_to_string(&state_file) {
         Ok(content) => {
             println!("[info] => Detected Tenderdash version: {}.", content);
             content == expected
         },
-        Err(_) => false,
+        Err(e) => {
+            eprintln!(
+                "[warn] => Failed to read download.state file {}: {}",
+                state_file.display(),
+                e
+            );
+            false
+        },
     }
 }
 

--- a/proto-compiler/src/functions.rs
+++ b/proto-compiler/src/functions.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     fs::{File, read_to_string},
-    io::Write,
+    io::{ErrorKind, Write},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -16,7 +16,12 @@ use crate::constants::{DEFAULT_TENDERDASH_COMMITISH, DEP_PROTOC_VERSION, Generat
 /// on cargo to decide wherther or not to call it. It means
 /// we will not be called too frequently, so the fetch will
 /// not happen too often.
-pub fn fetch_commitish(tenderdash_dir: &Path, cache_dir: &Path, url: &str, commitish: &str) {
+pub fn fetch_commitish(
+    tenderdash_dir: &Path,
+    cache_dir: &Path,
+    url: &str,
+    commitish: &str,
+) -> Result<(), String> {
     let url = format!("{url}/archive/{commitish}.zip");
 
     println!(
@@ -27,37 +32,42 @@ pub fn fetch_commitish(tenderdash_dir: &Path, cache_dir: &Path, url: &str, commi
 
     // ensure cache dir exists
     if !cache_dir.is_dir() {
-        std::fs::create_dir_all(cache_dir).expect(&format!(
-            "cannot create cache directory {}",
-            cache_dir.display()
-        ));
+        std::fs::create_dir_all(cache_dir)
+            .map_err(|e| format!("cannot create cache directory {}: {e}", cache_dir.display()))?;
     }
 
     let archive_file = cache_dir.join(format!("tenderdash-{}.zip", commitish));
     // Unzip Tenderdash sources to tmpdir and move to target/tenderdash
-    let tmpdir = tempfile::tempdir().expect("cannot create temporary dir to extract archive");
-    download_and_unzip(&url, archive_file.as_path(), tmpdir.path());
+    let tmpdir = tempfile::tempdir()
+        .map_err(|e| format!("cannot create temporary dir to extract archive: {e}"))?;
+    download_and_unzip(&url, archive_file.as_path(), tmpdir.path())?;
 
     // Downloaded zip contains subdirectory like tenderdash-0.12.0-dev.2. We need to
     // move its contents to target/tederdash, so that we get correct paths like
     // target/tenderdash/version/version.go
-    let src_dir = find_subdir(tmpdir.path(), "tenderdash-");
+    let src_dir = find_subdir(tmpdir.path(), "tenderdash-")?;
 
     let options = fs_extra::dir::CopyOptions::new().content_only(true);
 
-    fs_extra::dir::create(tenderdash_dir, true).expect(&format!(
-        "cannot create destination directory {}",
-        tenderdash_dir.display()
-    ));
-    fs_extra::dir::move_dir(src_dir, tenderdash_dir, &options).expect(&format!(
-        "cannot move tenderdash directory to {}",
-        tenderdash_dir.display()
-    ));
+    fs_extra::dir::create(tenderdash_dir, true).map_err(|e| {
+        format!(
+            "cannot create destination directory {}: {e}",
+            tenderdash_dir.display()
+        )
+    })?;
+    fs_extra::dir::move_dir(src_dir, tenderdash_dir, &options).map_err(|e| {
+        format!(
+            "cannot move tenderdash directory to {}: {e}",
+            tenderdash_dir.display()
+        )
+    })?;
+    Ok(())
 }
 
 /// Download file from URL and unzip it to `dest_dir`
-fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
+fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
     const RETRIES: usize = 2;
+    let mut last_err: Option<String> = None;
 
     for retry in 1..=RETRIES {
         println!(
@@ -67,8 +77,11 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
 
         if !archive_file.is_file() {
             println!("      [info] => Downloading {}", url);
-            download(url, archive_file)
-                .unwrap_or_else(|e| println!(" [error] => Cannot download archive: {:?}", e));
+            if let Err(e) = download(url, archive_file) {
+                println!(" [error] => Cannot download archive: {:?}", e);
+                last_err = Some(e);
+                continue;
+            }
         } else {
             println!(
                 "      [info] => Archive file {} already exists, skipping download",
@@ -81,13 +94,20 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
             archive_file.display()
         );
         match unzip(archive_file, dest_dir) {
-            Ok(_) => break,
+            Ok(_) => {
+                println!(
+                    "      [info] => Extracted tenderdash sources to {}",
+                    dest_dir.display()
+                );
+                return Ok(());
+            },
             Err(e) => {
                 println!(
                     "        [error] => Cannot unzip archive: {}: {:?}",
                     archive_file.display(),
                     e
                 );
+                last_err = Some(e);
             },
         }
 
@@ -96,10 +116,12 @@ fn download_and_unzip(url: &str, archive_file: &Path, dest_dir: &Path) {
             .unwrap_or_else(|_| println!("      [warn] => Cannot remove file: {:?}", archive_file));
     }
 
-    println!(
-        "      [info] => Extracted tenderdash sources to {}",
-        dest_dir.display()
-    );
+    Err(last_err.unwrap_or_else(|| {
+        format!(
+            "cannot download and extract tenderdash sources to {}",
+            dest_dir.display()
+        )
+    }))
 }
 
 /// Download file from URL
@@ -129,10 +151,8 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
         // no archive file, so we request another download
         return Err("archive file does not exist".to_string());
     }
-    let file = File::open(archive_file).expect(&format!(
-        "cannot open downloaded zip {}",
-        archive_file.display()
-    ));
+    let file = File::open(archive_file)
+        .unwrap_or_else(|e| panic!("cannot open downloaded zip {}: {e}", archive_file.display()));
     let mut archive =
         zip::ZipArchive::new(&file).map_err(|e| format!("cannot open zip archive: {:?}", e))?;
 
@@ -144,14 +164,14 @@ fn unzip(archive_file: &Path, dest_dir: &Path) -> Result<(), String> {
 }
 
 /// Find a subdirectory of a parent path which has provided name prefix
-fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
+fn find_subdir(parent: &Path, name_prefix: &str) -> Result<PathBuf, String> {
     let dir_content = fs_extra::dir::get_dir_content(parent)
-        .expect(&format!("cannot list tmp dir {}", parent.display()));
+        .map_err(|e| format!("cannot list tmp dir {}: {e}", parent.display()))?;
     let mut src_dir = String::new();
     for directory in dir_content.directories {
         let directory = Path::new(&directory)
             .file_name()
-            .expect("cannot extract dir name");
+            .ok_or_else(|| "cannot extract dir name".to_string())?;
 
         if directory.to_string_lossy().starts_with(name_prefix) {
             src_dir = directory.to_string_lossy().into();
@@ -159,13 +179,16 @@ fn find_subdir(parent: &Path, name_prefix: &str) -> PathBuf {
         };
     }
     if src_dir.is_empty() {
-        panic!("cannot find extracted Tenderdash sources")
+        return Err(format!(
+            "cannot find extracted Tenderdash sources in {}",
+            parent.display()
+        ));
     }
-    parent.join(src_dir)
+    Ok(parent.join(src_dir))
 }
 
 /// Walk through the list of directories and gather all *.proto files
-pub fn find_proto_files(proto_paths: Vec<PathBuf>) -> Vec<PathBuf> {
+pub fn find_proto_files(proto_paths: Vec<PathBuf>) -> Result<Vec<PathBuf>, String> {
     let mut protos: Vec<PathBuf> = vec![];
     for proto_path in &proto_paths {
         protos.append(
@@ -174,54 +197,57 @@ pub fn find_proto_files(proto_paths: Vec<PathBuf>) -> Vec<PathBuf> {
                 .filter_map(|e| e.ok())
                 .filter(|e| {
                     e.file_type().is_file()
-                        && e.path().extension().is_some()
-                        && e.path().extension().unwrap() == "proto"
+                        && e.path()
+                            .extension()
+                            .and_then(|ext| ext.to_str())
+                            .map(|ext| ext == "proto")
+                            .unwrap_or(false)
                 })
                 .map(|e| e.into_path())
                 .collect(),
         );
     }
-    protos
+    Ok(protos)
 }
 
-pub fn abci_version<T: AsRef<Path>>(dir: T) -> String {
+pub fn abci_version<T: AsRef<Path>>(dir: T) -> Result<String, String> {
     let mut file_path = dir.as_ref().to_path_buf();
     file_path.push("version/version.go");
 
-    let contents =
-        read_to_string(&file_path).expect(&format!("cannot read {}", file_path.display()));
+    let contents = read_to_string(&file_path)
+        .map_err(|e| format!("cannot read {}: {e}", file_path.display()))?;
     use regex::Regex;
 
-    let re = Regex::new(r##"(?m)^\s+ABCISemVer\s*=\s*"([^"]+)"\s+*$"##).unwrap();
+    let re = Regex::new(r##"(?m)^\s+ABCISemVer\s*=\s*"([^"]+)"\s+*$"##)
+        .map_err(|e| format!("invalid ABCISemVer regex: {e}"))?;
     let captures = re
         .captures(&contents)
-        .expect("cannot find ABCISemVer in version/version.go");
+        .ok_or_else(|| "cannot find ABCISemVer in version/version.go".to_string())?;
 
-    captures
+    let match_val = captures
         .get(1)
-        .expect("ABCISemVer not found in version/version.go")
-        .as_str()
-        .to_string()
+        .ok_or_else(|| "ABCISemVer not found in version/version.go".to_string())?;
+    Ok(match_val.as_str().to_string())
 }
 
-pub fn tenderdash_version<T: AsRef<Path>>(dir: T) -> String {
+pub fn tenderdash_version<T: AsRef<Path>>(dir: T) -> Result<String, String> {
     let mut file_path = dir.as_ref().to_path_buf();
     file_path.push("version/version.go");
 
-    let contents =
-        read_to_string(&file_path).expect(&format!("cannot read {}", file_path.display()));
+    let contents = read_to_string(&file_path)
+        .map_err(|e| format!("cannot read {}: {e}", file_path.display()))?;
     use regex::Regex;
 
-    let re = Regex::new(r##"(?m)^\s+TMVersionDefault\s*=\s*"([^"]+)"\s+*$"##).unwrap();
+    let re = Regex::new(r##"(?m)^\s+TMVersionDefault\s*=\s*"([^"]+)"\s+*$"##)
+        .map_err(|e| format!("invalid TMVersionDefault regex: {e}"))?;
     let captures = re
         .captures(&contents)
-        .expect("cannot find TMVersionDefault in version/version.go");
+        .ok_or_else(|| "cannot find TMVersionDefault in version/version.go".to_string())?;
 
-    captures
+    let match_val = captures
         .get(1)
-        .expect("TMVersionDefault not found in version/version.go")
-        .as_str()
-        .to_string()
+        .ok_or_else(|| "TMVersionDefault not found in version/version.go".to_string())?;
+    Ok(match_val.as_str().to_string())
 }
 
 /// Create tenderdash.rs with library information
@@ -231,16 +257,19 @@ pub fn generate_tenderdash_lib(
     abci_ver: &str,
     td_ver: &str,
     mode: &GenerationMode,
-) {
+) -> Result<(), String> {
     let mut file_names = WalkDir::new(prost_dir)
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_type().is_file()
-                && e.file_name().to_str().unwrap().starts_with("tendermint.")
-                && e.file_name().to_str().unwrap().ends_with(".rs")
+        .filter(|e| e.file_type().is_file())
+        .filter_map(|e| {
+            let file_name = e.file_name().to_str()?;
+            if file_name.starts_with("tendermint.") && file_name.ends_with(".rs") {
+                Some(file_name.to_string())
+            } else {
+                None
+            }
         })
-        .map(|d| d.file_name().to_str().unwrap().to_string())
         .collect::<Vec<_>>();
     file_names.sort();
 
@@ -248,14 +277,12 @@ pub fn generate_tenderdash_lib(
     let tab = "    ".to_string();
 
     for file_name in file_names {
-        let parts: Vec<_> = file_name
+        let trimmed = file_name
             .strip_prefix("tendermint.")
-            .unwrap()
+            .ok_or_else(|| format!("unexpected generated file name: {file_name}"))?
             .strip_suffix(".rs")
-            .unwrap()
-            .split('.')
-            .rev()
-            .collect();
+            .ok_or_else(|| format!("unexpected generated file name: {file_name}"))?;
+        let parts: Vec<_> = trimmed.split('.').rev().collect();
 
         let mut tab_count = parts.len();
 
@@ -274,6 +301,7 @@ pub fn generate_tenderdash_lib(
     }
 
     // Add meta
+    let commitish = tenderdash_commitish()?;
     content = format!(
         "{}
 pub mod meta {{
@@ -289,7 +317,7 @@ pub mod meta {{
 ",
         content,
         crate::constants::TENDERDASH_REPO,
-        tenderdash_commitish(),
+        commitish,
         abci_ver,
         td_ver,
         mode,
@@ -297,41 +325,44 @@ pub mod meta {{
     .trim_start()
     .into();
 
-    let mut file = File::create(tenderdash_lib_target).expect(&format!(
-        "tenderdash library file create failed {}",
-        tenderdash_lib_target.display()
-    ));
+    let mut file = File::create(tenderdash_lib_target).map_err(|e| {
+        format!(
+            "tenderdash library file create failed {}: {e}",
+            tenderdash_lib_target.display()
+        )
+    })?;
     file.write_all(content.as_bytes())
-        .expect("tenderdash library file write failed");
+        .map_err(|e| format!("tenderdash library file write failed: {e}"))?;
+    Ok(())
 }
 
-pub(crate) fn tenderdash_commitish() -> String {
-    match env::var("TENDERDASH_COMMITISH") {
+pub(crate) fn tenderdash_commitish() -> Result<String, String> {
+    let value = match env::var("TENDERDASH_COMMITISH") {
         Ok(v) => v,
         Err(_) => DEFAULT_TENDERDASH_COMMITISH.to_string(),
-    }
+    };
+    Ok(value)
 }
 
 /// Save the commitish of last successful download to a file in a state file,
 /// located in the `dir` directory and named `download.state`.
-pub(crate) fn save_state(dir: &Path, commitish: &str) {
+pub(crate) fn save_state(dir: &Path, commitish: &str) -> Result<(), String> {
     let state_file = PathBuf::from(&dir).join("download.state");
 
-    std::fs::write(&state_file, commitish)
-        .map_err(|e| {
-            println!(
-                "[warn] => Failed to write download.state file {}: {}",
-                state_file.display(),
-                e
-            );
-        })
-        .ok();
+    std::fs::write(&state_file, commitish).map_err(|e| {
+        format!(
+            "failed to write download.state file {}: {}",
+            state_file.display(),
+            e
+        )
+    })?;
+    Ok(())
 }
 
 /// Check if the state file contains the same commitish as the one we are trying
 /// to download. State file should be located in the `dir` and named
 /// `download.state`
-pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
+pub(crate) fn check_state(dir: &Path, commitish: &str) -> Result<bool, String> {
     let state_file = PathBuf::from(&dir).join("download.state");
 
     let expected = commitish.to_string();
@@ -339,16 +370,14 @@ pub(crate) fn check_state(dir: &Path, commitish: &str) -> bool {
     match read_to_string(&state_file) {
         Ok(content) => {
             println!("[info] => Detected Tenderdash version: {}.", content);
-            content == expected
+            Ok(content == expected)
         },
-        Err(e) => {
-            eprintln!(
-                "[warn] => Failed to read download.state file {}: {}",
-                state_file.display(),
-                e
-            );
-            false
-        },
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(format!(
+            "failed to read download.state file {}: {}",
+            state_file.display(),
+            e
+        )),
     }
 }
 
@@ -380,10 +409,11 @@ provided by your package manager may be outdated)";
         .map_err(|e| format!("output {:?} is not utf8 string: {}", out, e))?;
 
     // Extract the version number from string like `libprotoc 25.1`
-    let version: f32 = version_output
+    let version_str = version_output
         .split_whitespace()
         .last()
-        .unwrap()
+        .ok_or_else(|| format!("unexpected protoc --version output: {}", version_output))?;
+    let version: f32 = version_str
         .parse()
         .map_err(|e| format!("failed to parse protoc version {}: {}", version_output, e))?;
 

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -24,12 +24,12 @@ use crate::functions::{check_deps, check_state, save_state};
 pub fn proto_compile(mode: GenerationMode) -> Result<(), String> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let output_base = resolve_output_base();
+    let output_base = resolve_output_base()?;
     let prost_out_dir = output_base.join(mode.module_name());
     let tenderdash_lib_target = prost_out_dir.join("mod.rs");
 
     std::fs::create_dir_all(&prost_out_dir)
-        .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
+        .map_err(|e| format!("cannot create out dir {:?}: {e}", prost_out_dir))?;
 
     let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
@@ -73,7 +73,7 @@ pub fn proto_compile(mode: GenerationMode) -> Result<(), String> {
         // ensure we start clean when regenerating
         std::fs::remove_dir_all(&prost_out_dir).ok();
         std::fs::create_dir_all(&prost_out_dir)
-            .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
+            .map_err(|e| format!("cannot create out dir {:?}: {e}", prost_out_dir))?;
         println!("[info] => Fetching {TENDERDASH_REPO} at {commitish} into {tenderdash_dir:?}.");
         fetch_commitish(
             &PathBuf::from(&tenderdash_dir),
@@ -144,7 +144,7 @@ pub fn proto_compile(mode: GenerationMode) -> Result<(), String> {
                 .compile_with_config(pb, &protos, &proto_includes_paths)
                 .map_err(|e| format!("tonic compile failed: {e}"))?;
             #[cfg(not(feature = "grpc"))]
-            panic!("grpc feature is required to compile {}", mode);
+            return Err(format!("grpc feature is required to compile {}", mode));
         },
         GenerationMode::GrpcClient => {
             #[cfg(feature = "grpc")]
@@ -157,7 +157,7 @@ pub fn proto_compile(mode: GenerationMode) -> Result<(), String> {
                 .compile_with_config(pb, &protos, &proto_includes_paths)
                 .map_err(|e| format!("tonic compile failed: {e}"))?;
             #[cfg(not(feature = "grpc"))]
-            panic!("grpc feature is required to compile {}", mode);
+            return Err(format!("grpc feature is required to compile {}", mode));
         },
         GenerationMode::NoStd => {
             pb.compile_protos(&protos, &proto_includes_paths)
@@ -184,13 +184,12 @@ pub fn proto_compile(mode: GenerationMode) -> Result<(), String> {
 }
 
 /// Resolve output base directory for generated files.
-pub fn resolve_output_base() -> PathBuf {
+pub fn resolve_output_base() -> Result<PathBuf, String> {
     var("TENDERDASH_PROTO_OUT_DIR")
         .map(PathBuf::from)
         .or_else(|_| var("OUT_DIR").map(PathBuf::from))
-        .unwrap_or_else(|_| {
-            panic!(
-                "OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it"
-            )
+        .map_err(|_| {
+            "OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it"
+                .to_string()
         })
 }

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -151,7 +151,7 @@ pub fn proto_compile(mode: GenerationMode) {
     }
 
     println!(
-        "[info] => Generated files copied to {}.",
+        "[info] => Generated files written to {}.",
         prost_out_dir.display()
     );
 
@@ -167,7 +167,7 @@ pub fn proto_compile(mode: GenerationMode) {
     println!("[info] => Done!");
 }
 
-fn resolve_output_base() -> PathBuf {
+pub fn resolve_output_base() -> PathBuf {
     var("TENDERDASH_PROTO_OUT_DIR")
         .map(PathBuf::from)
         .or_else(|_| var("OUT_DIR").map(PathBuf::from))

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -21,7 +21,7 @@ use crate::functions::{check_deps, check_state, save_state};
 /// # Arguments
 ///
 /// * `module_name` - name of module to put generated files into
-pub fn proto_compile(mode: GenerationMode) {
+pub fn proto_compile(mode: GenerationMode) -> Result<(), String> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     let output_base = resolve_output_base();
@@ -50,17 +50,22 @@ pub fn proto_compile(mode: GenerationMode) {
 
     let thirdparty_dir = root.join("third_party");
 
-    let commitish = tenderdash_commitish();
+    let commitish = tenderdash_commitish()?;
 
     // ensure dependencies are up to date
-    if let Err(e) = check_deps() {
-        eprintln!("[error] => {}", e);
-        std::process::exit(1);
-    }
+    check_deps()?;
 
     // check if this commitish is already downloaded
-    let download = std::fs::metadata(tenderdash_dir.join("proto")).is_err()
-        || !check_state(&prost_out_dir, &commitish);
+    let download = match std::fs::metadata(tenderdash_dir.join("proto")) {
+        Ok(_) => !check_state(&prost_out_dir, &commitish)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            return Err(format!(
+                "cannot stat Tenderdash proto dir {}: {e}",
+                tenderdash_dir.join("proto").display()
+            ));
+        },
+    };
 
     if download {
         // ensure we start clean when regenerating
@@ -73,7 +78,7 @@ pub fn proto_compile(mode: GenerationMode) {
             &cargo_target_dir,
             TENDERDASH_REPO,
             &commitish,
-        ); // This panics if it fails.
+        )?;
     } else {
         println!("[info] => Skipping download.");
     }
@@ -83,7 +88,7 @@ pub fn proto_compile(mode: GenerationMode) {
     let proto_paths = vec![tenderdash_dir.join("proto").join("tendermint").join("abci")];
     let proto_includes_paths = vec![tenderdash_dir.join("proto"), thirdparty_dir];
     // List available proto files
-    let mut protos = find_proto_files(proto_paths);
+    let mut protos = find_proto_files(proto_paths)?;
     // On top of that, we add canonical.proto, required to verify signatures
     protos.push(
         tenderdash_dir
@@ -120,8 +125,8 @@ pub fn proto_compile(mode: GenerationMode) {
     );
 
     println!("[info] => Determining ABCI protocol version.");
-    let abci_ver = abci_version(&tenderdash_dir);
-    let tenderdash_ver = tenderdash_version(tenderdash_dir);
+    let abci_ver = abci_version(&tenderdash_dir)?;
+    let tenderdash_ver = tenderdash_version(tenderdash_dir)?;
 
     println!("[info] => Creating structs.");
 
@@ -135,7 +140,7 @@ pub fn proto_compile(mode: GenerationMode) {
                 .build_transport(true)
                 .generate_default_stubs(true)
                 .compile_with_config(pb, &protos, &proto_includes_paths)
-                .unwrap();
+                .map_err(|e| format!("tonic compile failed: {e}"))?;
             #[cfg(not(feature = "grpc"))]
             panic!("grpc feature is required to compile {}", mode);
         },
@@ -148,12 +153,13 @@ pub fn proto_compile(mode: GenerationMode) {
                 .build_transport(false)
                 .generate_default_stubs(true)
                 .compile_with_config(pb, &protos, &proto_includes_paths)
-                .unwrap();
+                .map_err(|e| format!("tonic compile failed: {e}"))?;
             #[cfg(not(feature = "grpc"))]
             panic!("grpc feature is required to compile {}", mode);
         },
         GenerationMode::NoStd => {
-            pb.compile_protos(&protos, &proto_includes_paths).unwrap();
+            pb.compile_protos(&protos, &proto_includes_paths)
+                .map_err(|e| format!("prost compile failed: {e}"))?;
         },
     }
 
@@ -168,10 +174,11 @@ pub fn proto_compile(mode: GenerationMode) {
         &abci_ver,
         &tenderdash_ver,
         &mode,
-    );
+    )?;
 
-    save_state(&prost_out_dir, &commitish);
+    save_state(&prost_out_dir, &commitish)?;
     println!("[info] => Done!");
+    Ok(())
 }
 
 /// Resolve output base directory for generated files.

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -34,10 +34,12 @@ pub fn proto_compile(mode: GenerationMode) {
     let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| output_base.join("tenderdash-cache"));
-    let tenderdash_dir = PathBuf::from(
-        var("TENDERDASH_DIR")
-            .unwrap_or_else(|_| output_base.join("tenderdash").to_str().unwrap().to_string()),
-    );
+    let tenderdash_dir = PathBuf::from(var("TENDERDASH_DIR").unwrap_or_else(|_| {
+        output_base
+            .join("tenderdash")
+            .to_string_lossy()
+            .into_owned()
+    }));
 
     println!(
         "[info] => Tenderdash cache dir: {}",

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -33,17 +33,25 @@ pub fn proto_compile(mode: GenerationMode) {
     std::fs::create_dir_all(&prost_out_dir)
         .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
 
-    let cargo_target_dir = match std::env::var("CARGO_TARGET_DIR") {
-        Ok(s) => PathBuf::from(s),
-        Err(_) => root.join("..").join("target"),
-    };
+    let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| output_base.join("tenderdash-cache"));
     let tenderdash_dir = PathBuf::from(var("TENDERDASH_DIR").unwrap_or_else(|_| {
-        cargo_target_dir
+        output_base
             .join("tenderdash")
             .to_str()
             .unwrap()
             .to_string()
     }));
+
+    println!(
+        "[info] => Tenderdash cache dir: {}",
+        cargo_target_dir.display()
+    );
+    println!(
+        "[info] => Tenderdash source dir: {}",
+        tenderdash_dir.display()
+    );
 
     let thirdparty_dir = root.join("third_party");
 

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -28,21 +28,16 @@ pub fn proto_compile(mode: GenerationMode) {
     let prost_out_dir = output_base.join(mode.module_name());
     let tenderdash_lib_target = prost_out_dir.join("mod.rs");
 
-    // ensure we start clean
-    std::fs::remove_dir_all(&prost_out_dir).ok();
     std::fs::create_dir_all(&prost_out_dir)
         .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
 
     let cargo_target_dir = std::env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| output_base.join("tenderdash-cache"));
-    let tenderdash_dir = PathBuf::from(var("TENDERDASH_DIR").unwrap_or_else(|_| {
-        output_base
-            .join("tenderdash")
-            .to_str()
-            .unwrap()
-            .to_string()
-    }));
+    let tenderdash_dir = PathBuf::from(
+        var("TENDERDASH_DIR")
+            .unwrap_or_else(|_| output_base.join("tenderdash").to_str().unwrap().to_string()),
+    );
 
     println!(
         "[info] => Tenderdash cache dir: {}",
@@ -68,6 +63,10 @@ pub fn proto_compile(mode: GenerationMode) {
         || !check_state(&prost_out_dir, &commitish);
 
     if download {
+        // ensure we start clean when regenerating
+        std::fs::remove_dir_all(&prost_out_dir).ok();
+        std::fs::create_dir_all(&prost_out_dir)
+            .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
         println!("[info] => Fetching {TENDERDASH_REPO} at {commitish} into {tenderdash_dir:?}.");
         fetch_commitish(
             &PathBuf::from(&tenderdash_dir),
@@ -175,6 +174,7 @@ pub fn proto_compile(mode: GenerationMode) {
     println!("[info] => Done!");
 }
 
+/// Resolve output base directory for generated files.
 pub fn resolve_output_base() -> PathBuf {
     var("TENDERDASH_PROTO_OUT_DIR")
         .map(PathBuf::from)

--- a/proto-compiler/src/lib.rs
+++ b/proto-compiler/src/lib.rs
@@ -1,11 +1,9 @@
 use std::{env::var, path::PathBuf};
 
-use tempfile::tempdir;
-
 mod functions;
 use functions::{
-    abci_version, copy_files, fetch_commitish, find_proto_files, generate_tenderdash_lib,
-    tenderdash_commitish, tenderdash_version,
+    abci_version, fetch_commitish, find_proto_files, generate_tenderdash_lib, tenderdash_commitish,
+    tenderdash_version,
 };
 
 mod constants;
@@ -26,17 +24,14 @@ use crate::functions::{check_deps, check_state, save_state};
 pub fn proto_compile(mode: GenerationMode) {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let prost_out_dir = root
-        .join("..")
-        .join("proto")
-        .join("src")
-        .join(mode.module_name());
+    let output_base = resolve_output_base();
+    let prost_out_dir = output_base.join(mode.module_name());
     let tenderdash_lib_target = prost_out_dir.join("mod.rs");
 
-    let out_dir = var("OUT_DIR")
-        .map(PathBuf::from)
-        .or_else(|_| tempdir().map(|d| d.into_path()))
-        .unwrap();
+    // ensure we start clean
+    std::fs::remove_dir_all(&prost_out_dir).ok();
+    std::fs::create_dir_all(&prost_out_dir)
+        .unwrap_or_else(|e| panic!("cannot create out dir {:?}: {e}", prost_out_dir));
 
     let cargo_target_dir = match std::env::var("CARGO_TARGET_DIR") {
         Ok(s) => PathBuf::from(s),
@@ -94,7 +89,7 @@ pub fn proto_compile(mode: GenerationMode) {
     let mut pb = prost_build::Config::new();
 
     // Compile proto files with added annotations, exchange prost_types to our own
-    pb.out_dir(&out_dir);
+    pb.out_dir(&prost_out_dir);
     pb.type_attribute(".", constants::SERIALIZED);
     for type_attribute in CUSTOM_TYPE_ATTRIBUTES {
         println!("[info] => Adding type attribute: {:?}", type_attribute);
@@ -127,6 +122,7 @@ pub fn proto_compile(mode: GenerationMode) {
         GenerationMode::GrpcServer => {
             #[cfg(feature = "grpc")]
             tonic_prost_build::configure()
+                .out_dir(prost_out_dir.clone())
                 .build_client(true)
                 .build_server(true)
                 .build_transport(true)
@@ -139,6 +135,7 @@ pub fn proto_compile(mode: GenerationMode) {
         GenerationMode::GrpcClient => {
             #[cfg(feature = "grpc")]
             tonic_prost_build::configure()
+                .out_dir(prost_out_dir.clone())
                 .build_client(true)
                 .build_server(false)
                 .build_transport(false)
@@ -153,11 +150,13 @@ pub fn proto_compile(mode: GenerationMode) {
         },
     }
 
-    println!("[info] => Removing old structs and copying new structs.");
-    copy_files(&out_dir, &prost_out_dir); // This panics if it fails.
+    println!(
+        "[info] => Generated files copied to {}.",
+        prost_out_dir.display()
+    );
 
     generate_tenderdash_lib(
-        &out_dir,
+        &prost_out_dir,
         &tenderdash_lib_target,
         &abci_ver,
         &tenderdash_ver,
@@ -166,4 +165,15 @@ pub fn proto_compile(mode: GenerationMode) {
 
     save_state(&prost_out_dir, &commitish);
     println!("[info] => Done!");
+}
+
+fn resolve_output_base() -> PathBuf {
+    var("TENDERDASH_PROTO_OUT_DIR")
+        .map(PathBuf::from)
+        .or_else(|_| var("OUT_DIR").map(PathBuf::from))
+        .unwrap_or_else(|_| {
+            panic!(
+                "OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it"
+            )
+        })
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, path::PathBuf};
 
 use tenderdash_proto_compiler::GenerationMode;
 
@@ -19,6 +19,16 @@ fn main() {
     // note it should be safe to build both server and client; we will just not use
     // them in the lib.rs
 
+    let output_base = proto_output_base();
+    println!(
+        "[info] => Using Tenderdash proto output dir: {}",
+        output_base.display()
+    );
+    println!(
+        "cargo:rustc-env=TENDERDASH_PROTO_OUT_DIR={}",
+        output_base.display()
+    );
+
     #[cfg(feature = "server")]
     // build gRPC server (includes client)
     tenderdash_proto_compiler::proto_compile(GenerationMode::GrpcServer);
@@ -32,4 +42,12 @@ fn main() {
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=TENDERDASH_COMMITISH");
+    println!("cargo:rerun-if-env-changed=TENDERDASH_PROTO_OUT_DIR");
+}
+
+fn proto_output_base() -> PathBuf {
+    env::var("TENDERDASH_PROTO_OUT_DIR")
+        .or_else(|_| env::var("OUT_DIR"))
+        .map(PathBuf::from)
+        .expect("OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it")
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -31,16 +31,22 @@ fn main() {
 
     #[cfg(feature = "server")]
     // build gRPC server (includes client)
-    tenderdash_proto_compiler::proto_compile(GenerationMode::GrpcServer);
+    run_proto_compile(GenerationMode::GrpcServer);
     #[cfg(feature = "client")]
     // build gRPC client only
-    tenderdash_proto_compiler::proto_compile(GenerationMode::GrpcClient);
+    run_proto_compile(GenerationMode::GrpcClient);
     // we always build nostd version
-    tenderdash_proto_compiler::proto_compile(GenerationMode::NoStd);
+    run_proto_compile(GenerationMode::NoStd);
 
     println!("cargo:rerun-if-changed=../proto-compiler/src");
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=TENDERDASH_COMMITISH");
     println!("cargo:rerun-if-env-changed=TENDERDASH_PROTO_OUT_DIR");
+}
+
+fn run_proto_compile(mode: GenerationMode) {
+    if let Err(e) = tenderdash_proto_compiler::proto_compile(mode) {
+        panic!("[error] => proto compile failed: {e}");
+    }
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -19,7 +19,10 @@ fn main() {
     // note it should be safe to build both server and client; we will just not use
     // them in the lib.rs
 
-    let output_base = resolve_output_base();
+    let output_base = resolve_output_base().unwrap_or_else(|e| {
+        eprintln!("[error] => resolve output base failed: {e}");
+        std::process::exit(1);
+    });
     println!(
         "[info] => Using Tenderdash proto output dir: {}",
         output_base.display()
@@ -47,6 +50,7 @@ fn main() {
 
 fn run_proto_compile(mode: GenerationMode) {
     if let Err(e) = tenderdash_proto_compiler::proto_compile(mode) {
-        panic!("[error] => proto compile failed: {e}");
+        eprintln!("[error] => proto compile failed: {e}");
+        std::process::exit(1);
     }
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,6 @@
-use std::{env, path::PathBuf};
+use std::env;
 
-use tenderdash_proto_compiler::GenerationMode;
+use tenderdash_proto_compiler::{GenerationMode, resolve_output_base};
 
 fn main() {
     // default Tenderdash version to use if TENDERDASH_COMMITISH is not set
@@ -19,7 +19,7 @@ fn main() {
     // note it should be safe to build both server and client; we will just not use
     // them in the lib.rs
 
-    let output_base = proto_output_base();
+    let output_base = resolve_output_base();
     println!(
         "[info] => Using Tenderdash proto output dir: {}",
         output_base.display()
@@ -43,11 +43,4 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=TENDERDASH_COMMITISH");
     println!("cargo:rerun-if-env-changed=TENDERDASH_PROTO_OUT_DIR");
-}
-
-fn proto_output_base() -> PathBuf {
-    env::var("TENDERDASH_PROTO_OUT_DIR")
-        .or_else(|_| env::var("OUT_DIR"))
-        .map(PathBuf::from)
-        .expect("OUT_DIR should be provided by Cargo; set TENDERDASH_PROTO_OUT_DIR to override it")
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -37,16 +37,22 @@ use prost::{Message, encoding::encoded_len_varint};
 #[cfg(not(any(feature = "server", feature = "client")))]
 #[rustfmt::skip]
 #[allow(clippy::empty_docs)]
-pub mod tenderdash_nostd;
+pub mod tenderdash_nostd {
+    include!(concat!(env!("TENDERDASH_PROTO_OUT_DIR"), "/tenderdash_nostd/mod.rs"));
+}
 
 #[cfg(feature = "server")]
 #[rustfmt::skip]
 #[allow(clippy::empty_docs)]
-pub mod tenderdash_grpc;
+pub mod tenderdash_grpc {
+    include!(concat!(env!("TENDERDASH_PROTO_OUT_DIR"), "/tenderdash_grpc/mod.rs"));
+}
 #[cfg(feature = "client")]
 #[rustfmt::skip]
 #[allow(clippy::empty_docs)]
-pub mod tenderdash_grpc_client;
+pub mod tenderdash_grpc_client {
+    include!(concat!(env!("TENDERDASH_PROTO_OUT_DIR"), "/tenderdash_grpc_client/mod.rs"));
+}
 
 // Now, re-export correct module
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

As AI correctly pointed out, using panics and expect is not a good coding practice.

## What was done?

Refactored proto-compiler functions to return error instead of panics.

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced panics and silent failures with descriptive, propagated errors across the proto compilation and download/extract flows for more reliable failure reporting.

* **Refactor**
  * Unified error handling and return types throughout the build/compile pipeline to improve stability and diagnostics.

* **Chores**
  * Build script updated to wrap compilation calls and exit with clear messages on failure for consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->