### PR TITLE
build(deps): bump bincode to 2.0.1 (only used in tests)

### DIFF
--- a/abci/Cargo.toml
+++ b/abci/Cargo.toml
@@ -85,8 +85,7 @@ futures = { version = "0.3.30", optional = true }
 [dev-dependencies]
 anyhow = { version = "1.0.82" }
 # Dash Platform requires specific version of bincode
-bincode = { version = "=2.0.0-rc.3" }
-bincode_derive = { version = "=2.0.0-rc.3" }
+bincode = { version = "=2.0.1" }
 blake2 = { version = "0.10.6" }
 bollard = { version = "0.20" }
 futures = { version = "0.3.30" }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -56,9 +56,7 @@ serde = ["dep:serde", "bytes/serde"]
 
 [dependencies]
 bytes = { version = "1.7", default-features = false }
-prost = { version = "0.14", default-features = false, features = [
-    "derive",
-] }
+prost = { version = "0.14", default-features = false, features = ["derive"] }
 tonic = { version = "0.14.2", optional = true, default-features = false }
 tonic-prost = { version = "0.14.2", optional = true }
 serde = { version = "1.0.208", default-features = false, features = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Bincode is outdated.

## What was done?

Updated bincode to last supported version 2.0.1.
Most likely we'll move on to some fork of bincode in the future.

## How Has This Been Tested?

GHA

## Breaking Changes

None, only tests affected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bincode development dependencies to version 2.0.1 from release candidate
  * Refined protocol buffer dependencies configuration and made serde an optional dependency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->