### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.5.1] - 2026-04-24
+
+### Changed
+
+- **MSRV bumped to `1.88`** (was `1.85`) — required by the `zip` 8.5 build-dependency in `tenderdash-proto-compiler`. Consumers of `tenderdash-proto` must build with rustc ≥ 1.88.
+- `zip` build-dependency updated from `7.0` to `8.5` in `tenderdash-proto-compiler` (#193).
+- Reference Dockerfiles bumped from `rust:1.85-*` to `rust:1.88-*`.
+
+### Fixed
+
+- `tenderdash-proto-compiler`: actionable download-hint message and stale-archive cleanup in the Tenderdash source fetch script (#188).
+- `tenderdash-abci` tests: updated `bollard` import to use `bollard::models::ContainerCreateBody` (bollard 0.20.2 dropped the re-export via `bollard::secret::*`).
+
+### CI / Build
+
+- `actions/upload-artifact` 6 → 7 (#183).
+- `docker/setup-buildx-action` 3.12.0 → 4.0.0 (#185).
+- `docker/build-push-action` 6.18.0 → 7.0.0 (#186) and 7.0.0 → 7.1.0 (#194).
+- `actions/deploy-pages` 4 → 5 (#191).
+- `actions/configure-pages` 5 → 6 (#192).
+- `actions/upload-pages-artifact` 4 → 5 (#195).
+
+[1.5.1]: https://github.com/dashpay/rs-tenderdash-abci/compare/v1.5.0...v1.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ members = ["abci", "proto-compiler", "proto"]
 
 [workspace.package]
 
-rust-version = "1.85"
-version = "1.5.0"
+rust-version = "1.88"
+version = "1.5.1"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Cuts patch release `v1.5.1` off `develop`. Collects nine dependency bumps and one build-script fix that have accumulated since `v1.5.0` (2026-01-27), plus an MSRV update forced by the `zip` 8.5 build-dependency.

## What was done?

- Bumped workspace version `1.5.0` → `1.5.1`.
- Bumped `rust-version` `"1.85"` → `"1.88"` — required by `zip` 8.5 in `tenderdash-proto-compiler` (a `[build-dependencies]` of `tenderdash-proto`, so it propagates to all downstream consumers).
- Added `CHANGELOG.md` (Keep a Changelog format) with the full `[1.5.1]` entry covering PRs #183, #185, #186, #188, #191, #192, #193, #194, #195.

## How Has This Been Tested?

- `cargo check --workspace` — clean at `1.5.1`.
- All CI checks on `develop` have been green since merging the nine PRs (see individual PRs for per-change verification).

## Breaking Changes

**Effective MSRV bump**: `tenderdash-proto-compiler` now requires rustc ≥ 1.88 (via `zip` 8.5). Because `proto-compiler` is a `[build-dependencies]` of `tenderdash-proto`, every downstream consumer building `tenderdash-proto` needs rustc ≥ 1.88. Reflected in `rust-version = "1.88"` so `cargo` gives a clean error on older toolchains instead of a cryptic `zip` MSRV failure.

Per Rust API Guidelines this is a minor bump, but releasing as patch per maintainer preference; MSRV change is documented in the changelog.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests (N/A — release metadata only)
- [x] I have made corresponding changes to the documentation (CHANGELOG.md created)

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

## Post-merge steps

After merging:
1. Tag `v1.5.1` on the resulting `develop` HEAD and push.
2. Pushing the tag triggers `.github/workflows/release.yml` → runs `./release.sh` → publishes to crates.io (needs `CRATES_TOKEN`).
3. Open a companion PR in `dashpay/platform` to bump the `tenderdash-abci` / `tenderdash-proto` refs to `v1.5.1` (45 Cargo.toml files touched by `scripts/release.sh`; not included here).

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.5.1
  * Updated minimum Rust version requirement to 1.88
  * Bumped dependencies and Docker base images
  * Upgraded CI/build workflow action versions

* **Bug Fixes**
  * Resolved test suite issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->